### PR TITLE
Fix type error

### DIFF
--- a/R/extract_gof.R
+++ b/R/extract_gof.R
@@ -30,6 +30,9 @@ extract_gof <- function(model, fmt = '%.3f', gof_map = NULL) {
         if (inherits(gof[[i]], 'numeric')) {
             gof[[i]] <- rounding(gof[[i]], gof_map$fmt[i])
         }
+        else {	
+            gof[[i]] <- as.character(gof[[i]])	
+        }
     }
 
     # reshape


### PR DESCRIPTION
It looks like the last update broke the msummary function. This fix ensures that the gof object consists only of characters so that the `pivot_longer` function will not throw a type error.