### PR TITLE
Export tidy.mira again

### DIFF
--- a/R/tidiers.R
+++ b/R/tidiers.R
@@ -13,7 +13,10 @@ generics::glance
 #' @param conf.level Confidence level for intervals. Defaults to .95
 #' @param ... extra arguments (not used)
 #'
+#' @export
 #' @keywords internal
+#' @family tidiers
+#'
 #' @note
 #' Available stats in result:
 #' \itemize{


### PR DESCRIPTION
This was the case in earlier versions and is apparently needed for modelsummary::tidy() to do what it should do? (See issue #57)