### PR TITLE
Export tidy.mira as S3 method like glance.mira is currently exported

### DIFF
--- a/R/tidiers.R
+++ b/R/tidiers.R
@@ -12,7 +12,7 @@ generics::glance
 #' @param conf.int Logical. Should confidence intervals be returned. Defaults to true.
 #' @param conf.level Confidence level for intervals. Defaults to .95
 #' @param ... extra arguments (not used)
-#'
+#' @export
 #' @keywords internal
 #' @note
 #' Available stats in result:


### PR DESCRIPTION
You are currently exporting glance.mira as an S3 method but not tidy.mira. That seems inconsistent and does not allow one to run tidy(model) to see what errors can be retrieved by modelsummary - so it would be great to export both (they are not visible separately but will just be called when calling tidy() or glance()