### PR TITLE
add exponentiate option to modelsummary

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -24,10 +24,11 @@ extract <- function(models,
                     add_rows = NULL,
                     add_rows_location = NULL,
                     stars = FALSE,
-                    fmt = '%.3f') {
+                    fmt = '%.3f',
+                    exponentiate = FALSE) {
 
 
-    # models must be a list of models or a single model 
+    # models must be a list of models or a single model
     # TODO: this is code repetition from modelsummary(), but we need it over there
     # as well for sanity checks. This doesn't matter at all, but maybe there's
     # a more elegant solution.
@@ -59,7 +60,8 @@ extract <- function(models,
                                       statistic_override = statistic_override[[i]],
                                       statistic_vertical = statistic_vertical,
                                       conf_level = conf_level,
-                                      stars = stars)
+                                      stars = stars,
+                                      exponentiate = exponentiate)
 
         # coef_map: omit, rename (must be done before join to collapse rows)
         if (!is.null(coef_map)) {
@@ -83,7 +85,7 @@ extract <- function(models,
         colnames(est[[i]])[3] <- model_names[i]
     }
 
-    est <- est %>% 
+    est <- est %>%
            purrr::reduce(dplyr::full_join, by = c('term', 'statistic'))  %>%
            dplyr::mutate(group = 'estimates') %>%
            dplyr::select(group, term, statistic, names(.))
@@ -117,7 +119,7 @@ extract <- function(models,
 	gof_names[is.na(gof_names)] <- gof$term[is.na(gof_names)]
     gof$term <- gof_names
 	idx <- match(gof$term, gof_map$clean) # reorder
-    gof <- gof[order(idx, gof$term),] 
+    gof <- gof[order(idx, gof$term),]
 
     # add_rows: this needs to be done after sorting and combining to preserve
     # user-selected row order

--- a/R/extract_estimates.R
+++ b/R/extract_estimates.R
@@ -10,7 +10,8 @@ extract_estimates <- function(model,
                               statistic_vertical = TRUE,
                               conf_level = .95,
                               fmt = '%.3f',
-                              stars = FALSE) {
+                              stars = FALSE,
+                              exponentiate = FALSE) {
 
     # statistic override
     if (!is.null(statistic_override)) {
@@ -31,9 +32,9 @@ extract_estimates <- function(model,
 
         # extract estimates
         if ('conf.int' %in% statistic) {
-            est <- tidy(model, conf.int = TRUE, conf.level = conf_level)
+            est <- tidy(model, conf.int = TRUE, conf.level = conf_level, exponentiate = exponentiate)
         } else {
-            est <- tidy(model)
+            est <- tidy(model,exponentiate = exponentiate)
         }
     }
 

--- a/R/modelsummary.R
+++ b/R/modelsummary.R
@@ -20,6 +20,7 @@ globalVariables(c('.', 'term', 'group', 'estimate', 'conf.high', 'conf.low', 'va
 #' @param stars FALSE for no significance stars. TRUE for default significance
 #' stars (*=.1, **=.05, ***=.01). Named numeric vector for custom significance
 #' stars. For example, `c('*' = .1, '+' = .05)`
+#' @param exponentiate TRUE for exponentiated estimates. FALSE for default estimates.
 #' @param statistic string name of the statistic to include in parentheses
 #' below estimates. Must be either "conf.int", or one of the column names
 #' produced by the `broom::tidy` function. Typical values include: "std.error",
@@ -84,9 +85,9 @@ globalVariables(c('.', 'term', 'group', 'estimate', 'conf.high', 'conf.low', 'va
 #'
 #' # modify list of GOF statistics and their format using the built-in
 #' # 'gof_map' data frame as a starting point
-#' gof_custom <- modelsummary::gof_map 
-#' gof_custom$omit[gof_custom$raw == 'deviance'] <- FALSE 
-#' gof_custom$fmt[gof_custom$raw == 'r.squared'] <- "%.5f" 
+#' gof_custom <- modelsummary::gof_map
+#' gof_custom$omit[gof_custom$raw == 'deviance'] <- FALSE
+#' gof_custom$fmt[gof_custom$raw == 'r.squared'] <- "%.5f"
 #' msummary(models, gof_map = gof_custom)
 #' }
 #'
@@ -104,6 +105,7 @@ modelsummary <- function(models,
                          gof_omit = NULL,
                          fmt = '%.3f',
                          stars = FALSE,
+                         exponentiate = FALSE,
                          title = NULL,
                          subtitle = NULL,
                          notes = NULL,
@@ -147,7 +149,8 @@ modelsummary <- function(models,
                               stars = stars,
                               add_rows = add_rows,
                               add_rows_location = add_rows_location,
-                              fmt = fmt)
+                              fmt = fmt,
+                              exponentiate = exponentiate)
 
     # remove duplicate term labels
     idx <- stringr::str_detect(dat$statistic, 'statistic\\d*$')

--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -18,7 +18,8 @@ extract(
   add_rows = NULL,
   add_rows_location = NULL,
   stars = FALSE,
-  fmt = "\%.3f"
+  fmt = "\%.3f",
+  exponentiate = FALSE
 )
 }
 \arguments{
@@ -73,6 +74,8 @@ stars. For example, `c('*' = .1, '+' = .05)`}
 string is passed to the `sprintf` function. '\%.3f' will keep 3 digits after
 the decimal point with trailing zero. '\%.5f' will keep 5 digits. '\%.3e' will
 use exponential notation. See `?sprintf` for more options.}
+
+\item{exponentiate}{TRUE for exponentiated estimates. FALSE for default estimates.}
 }
 \value{
 tibble

--- a/man/extract_estimates.Rd
+++ b/man/extract_estimates.Rd
@@ -11,7 +11,8 @@ extract_estimates(
   statistic_vertical = TRUE,
   conf_level = 0.95,
   fmt = "\%.3f",
-  stars = FALSE
+  stars = FALSE,
+  exponentiate = FALSE
 )
 }
 \arguments{
@@ -44,6 +45,8 @@ use exponential notation. See `?sprintf` for more options.}
 \item{stars}{FALSE for no significance stars. TRUE for default significance
 stars (*=.1, **=.05, ***=.01). Named numeric vector for custom significance
 stars. For example, `c('*' = .1, '+' = .05)`}
+
+\item{exponentiate}{TRUE for exponentiated estimates. FALSE for default estimates.}
 }
 \value{
 data.frame with side-by-side model summaries

--- a/man/modelsummary.Rd
+++ b/man/modelsummary.Rd
@@ -16,6 +16,7 @@ modelsummary(
   gof_omit = NULL,
   fmt = "\%.3f",
   stars = FALSE,
+  exponentiate = FALSE,
   title = NULL,
   subtitle = NULL,
   notes = NULL,
@@ -69,6 +70,8 @@ use exponential notation. See `?sprintf` for more options.}
 \item{stars}{FALSE for no significance stars. TRUE for default significance
 stars (*=.1, **=.05, ***=.01). Named numeric vector for custom significance
 stars. For example, `c('*' = .1, '+' = .05)`}
+
+\item{exponentiate}{TRUE for exponentiated estimates. FALSE for default estimates.}
 
 \item{title}{string}
 
@@ -126,9 +129,9 @@ msummary(models, notes = list('A first note', gt::md('A **bold** note')))
 
 # modify list of GOF statistics and their format using the built-in
 # 'gof_map' data frame as a starting point
-gof_custom <- modelsummary::gof_map 
-gof_custom$omit[gof_custom$raw == 'deviance'] <- FALSE 
-gof_custom$fmt[gof_custom$raw == 'r.squared'] <- "\%.5f" 
+gof_custom <- modelsummary::gof_map
+gof_custom$omit[gof_custom$raw == 'deviance'] <- FALSE
+gof_custom$fmt[gof_custom$raw == 'r.squared'] <- "\%.5f"
 msummary(models, gof_map = gof_custom)
 }
 

--- a/man/msummary.Rd
+++ b/man/msummary.Rd
@@ -16,6 +16,7 @@ msummary(
   gof_omit = NULL,
   fmt = "\%.3f",
   stars = FALSE,
+  exponentiate = FALSE,
   title = NULL,
   subtitle = NULL,
   notes = NULL,
@@ -69,6 +70,8 @@ use exponential notation. See `?sprintf` for more options.}
 \item{stars}{FALSE for no significance stars. TRUE for default significance
 stars (*=.1, **=.05, ***=.01). Named numeric vector for custom significance
 stars. For example, `c('*' = .1, '+' = .05)`}
+
+\item{exponentiate}{TRUE for exponentiated estimates. FALSE for default estimates.}
 
 \item{title}{string}
 
@@ -126,9 +129,9 @@ msummary(models, notes = list('A first note', gt::md('A **bold** note')))
 
 # modify list of GOF statistics and their format using the built-in
 # 'gof_map' data frame as a starting point
-gof_custom <- modelsummary::gof_map 
-gof_custom$omit[gof_custom$raw == 'deviance'] <- FALSE 
-gof_custom$fmt[gof_custom$raw == 'r.squared'] <- "\%.5f" 
+gof_custom <- modelsummary::gof_map
+gof_custom$omit[gof_custom$raw == 'deviance'] <- FALSE
+gof_custom$fmt[gof_custom$raw == 'r.squared'] <- "\%.5f"
 msummary(models, gof_map = gof_custom)
 }
 


### PR DESCRIPTION
This is a minor change, but I added the 'exponentiate' option to modelsummary. It allows to report directly exponentiated estimates. It can be useful for Cox models for example.