### PR TITLE
Report FE and clusters for felm objects by default

### DIFF
--- a/R/glance_custom.R
+++ b/R/glance_custom.R
@@ -34,3 +34,17 @@ glance_custom.fixest <- function(x) {
   row.names(out) <- NULL
   return(out)
 }
+
+#' @inherit glance_custom
+#' @keywords internal
+#' @export
+glance_custom.felm <- function(x) {
+	out <- tibble::tibble(.rows = 1)
+	for (n in names(x$fe)) {
+		out[[paste('FE: ', n)]] <- 'X'
+	}
+	if (!is.null(names(x$clustervar))) {
+		out[['Cluster vars']] <- paste(names(x$clustervar), collapse = ' + ')
+	}
+	return(out)
+}


### PR DESCRIPTION
Another minor PR, this time to make the default output of `felm` objects similar to that of `fixest` objects.

    library(lfe)
    #> Loading required package: Matrix
    library(modelsummary)

    url <- 'https://vincentarelbundock.github.io/Rdatasets/csv/plm/EmplUK.csv'
    dat <- read.csv(url)

    mod <- list()
    mod[[1]] <- felm(emp ~ wage, dat)
    mod[[2]] <- felm(emp ~ wage | firm + year, dat)
    mod[[3]] <- felm(emp ~ wage | firm + year | 0 | firm, dat)
    mod[[4]] <- felm(emp ~ wage | firm + year | 0 | firm + year, dat)

    msummary(mod, output = "markdown")

<table>
<thead>
<tr class="header">
<th style="text-align: left;"></th>
<th style="text-align: left;">Model 1</th>
<th style="text-align: left;">Model 2</th>
<th style="text-align: left;">Model 3</th>
<th style="text-align: left;">Model 4</th>
</tr>
</thead>
<tbody>
<tr class="odd">
<td style="text-align: left;">(Intercept)</td>
<td style="text-align: left;">15.228</td>
<td style="text-align: left;"></td>
<td style="text-align: left;"></td>
<td style="text-align: left;"></td>
</tr>
<tr class="even">
<td style="text-align: left;"></td>
<td style="text-align: left;">(2.149)</td>
<td style="text-align: left;"></td>
<td style="text-align: left;"></td>
<td style="text-align: left;"></td>
</tr>
<tr class="odd">
<td style="text-align: left;">wage</td>
<td style="text-align: left;">-0.307</td>
<td style="text-align: left;">-0.062</td>
<td style="text-align: left;">-0.062</td>
<td style="text-align: left;">-0.062</td>
</tr>
<tr class="even">
<td style="text-align: left;"></td>
<td style="text-align: left;">(0.087)</td>
<td style="text-align: left;">(0.039)</td>
<td style="text-align: left;">(0.050)</td>
<td style="text-align: left;">(0.054)</td>
</tr>
<tr class="odd">
<td style="text-align: left;">Num.Obs.</td>
<td style="text-align: left;">1031</td>
<td style="text-align: left;">1031</td>
<td style="text-align: left;">1031</td>
<td style="text-align: left;">1031</td>
</tr>
<tr class="even">
<td style="text-align: left;">R2</td>
<td style="text-align: left;">0.012</td>
<td style="text-align: left;">0.983</td>
<td style="text-align: left;">0.983</td>
<td style="text-align: left;">0.983</td>
</tr>
<tr class="odd">
<td style="text-align: left;">R2 Adj.</td>
<td style="text-align: left;">0.011</td>
<td style="text-align: left;">0.980</td>
<td style="text-align: left;">0.980</td>
<td style="text-align: left;">0.980</td>
</tr>
<tr class="even">
<td style="text-align: left;">Cluster vars</td>
<td style="text-align: left;"></td>
<td style="text-align: left;"></td>
<td style="text-align: left;">firm</td>
<td style="text-align: left;">firm + year</td>
</tr>
<tr class="odd">
<td style="text-align: left;">FE: firm</td>
<td style="text-align: left;"></td>
<td style="text-align: left;">X</td>
<td style="text-align: left;">X</td>
<td style="text-align: left;">X</td>
</tr>
<tr class="even">
<td style="text-align: left;">FE: year</td>
<td style="text-align: left;"></td>
<td style="text-align: left;">X</td>
<td style="text-align: left;">X</td>
<td style="text-align: left;">X</td>
</tr>
</tbody>
</table>

<sup>Created on 2020-10-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>