### PR TITLE
Added "pearspear" option to datasummary_correlation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,10 +10,14 @@ Description: Create beautiful and customizable tables to summarize several
     Excel, RTF, JPG, or PNG. Tables can easily be embedded in 'Rmarkdown' or 
     'knitr' dynamic documents.
 Version: 0.6.6
-Authors@R: person("Vincent", "Arel-Bundock", 
-                  email = "vincent.arel-bundock@umontreal.ca", 
-                  role = c("aut", "cre"),
-                  comment = c(ORCID = "0000-0003-2042-7063"))
+Authors@R: c(person("Vincent", "Arel-Bundock", 
+                   email = "vincent.arel-bundock@umontreal.ca", 
+                   role = c("aut", "cre"),
+                   comment = c(ORCID = "0000-0003-2042-7063")),
+            person("Joachim", "Gassen", 
+                   email = "gassen@wiwi.hu-berlin.de",
+                   role = "ctb",
+                   comment = c(ORCID = "0000-0003-4364-2911")))
 URL: https://vincentarelbundock.github.io/modelsummary/
 BugReports: https://github.com/vincentarelbundock/modelsummary/issues/
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # modelsummary 0.6.6.9000
 
-* `method` argument for `datasummary_correlation`
+* `method` argument for `datasummary_correlation`, including "pearspear" for Pearson correlations above and Spearman correlations below the diagonal
 * `coef_map` accepts unnamed vectors
 * `fixest::fixest_multi` support
 * `get_gof` forwards ... to `model_performance`

--- a/man/datasummary_correlation.Rd
+++ b/man/datasummary_correlation.Rd
@@ -36,7 +36,8 @@ datasummary_correlation(
 
 \item{method}{character or function
 \itemize{
-  \item character: "pearson", "kendall", or "spearman"
+  \item character: "pearson", "kendall", "spearman", or "pearspear"
+    (Pearson correlations above and Spearman correlations below the diagonal)
   \item function: takes a data.frame with numeric columns and returns a
   square matrix with unique row.names and colnames.
 }}

--- a/tests/testthat/test-datasummary_correlation.R
+++ b/tests/testthat/test-datasummary_correlation.R
@@ -11,7 +11,7 @@ test_that("pearson equals pearson", {
   expect_equal(a, b)
 })
 
-test_that("pearson, kendall, spearman", {
+test_that("pearson, kendall, spearman, pearspear", {
   dat <- mtcars[, c("mpg", "hp")]
 
   # pearson
@@ -28,5 +28,11 @@ test_that("pearson, kendall, spearman", {
   tab <- datasummary_correlation(dat, output = "data.frame", method = "spearman")
   truth <- structure(list(` ` = c("mpg", "hp"), mpg = c("1", "-.89"), hp = c(".", "1")), row.names = c(NA, -2L), class = "data.frame", align = "lrr", output_format = "dataframe")
   expect_equal(truth, tab)
+
+  # pearspear
+  tab <- datasummary_correlation(dat, output = "data.frame", method = "pearspear")
+  truth <- structure(list(` ` = c("mpg", "hp"), mpg = c("1", "-.89"), hp = c("-.78", "1")), row.names = c(NA, -2L), class = "data.frame", align = "lrr", output_format = "dataframe")
+  expect_equal(truth, tab)
+
 })
 


### PR DESCRIPTION
Hi there! Thank you very much for this extremely useful and well-designed package. This small PR introduces the additional method "pearspear" to `datasummary_correlation()`. It prints Pearson correlations above and Spearman correlations below the diagonal. This concise way of reporting correlations seems fairly common across several fields. While in principle it would also be feasible to implement this via providing a function to `method` in the current version of the code that would not work as `datasummary_correlation()` erases the upper triangle of the correlation matrix.

Needless to say: Feel free to discard. The PR includes documentation, test code and a short addition to NEWS.md. 