### PR TITLE
changes warnings to errors when vcov cannot adjust standard errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,11 @@ Authors@R: c(person("Vincent", "Arel-Bundock",
             person("Moritz", "Schwarz", 
                    email = "moritz.schwarz@scmo.eu",
                    role = "ctb",
-                   comment = c(ORCID = "0000-0003-0340-3780")))
+                   comment = c(ORCID = "0000-0003-0340-3780")),
+            person("Benjamin", "Elbers",
+                   email = "be2239@columbia.edu",
+                   role = "ctb",
+                   comment = c(ORDIC = "0000-0001-5392-3448")))
 URL: https://vincentarelbundock.github.io/modelsummary/
 BugReports: https://github.com/vincentarelbundock/modelsummary/issues/
 Depends:

--- a/R/get_vcov.R
+++ b/R/get_vcov.R
@@ -10,6 +10,11 @@ get_vcov <- function(model, vcov = NULL, conf_level = NULL, ...) {
   # needed for logic tests
   out <- mat <- NULL
 
+  msg_vcov_error <- c(
+    "The variance-covariance matrix is required to adjust the standard errors. ",
+    "The `vcov` argument accepts a variance-covariance matrix, a vector of standard errors, or a ",
+    "function that returns one of these, such as `stats::vcov`.")
+
   if (is.null(vcov)) {
     return(NULL)
   }
@@ -65,10 +70,8 @@ get_vcov <- function(model, vcov = NULL, conf_level = NULL, ...) {
     }
 
     if (!inherits(mat, "matrix")) {
-      msg <- paste0("Unable to extract a variance-covariance matrix of type %s from model of class %s. ",
-        "You might be able to calculate a variance-covariance matrix for the model by using ",
-        "an external function, and then supply this matrix to modelsummary directly using the vcov argument.",
-        collapse = "")
+      msg <- paste0(c("Unable to extract a variance-covariance matrix of type %s from model of class %s. ",
+        msg_vcov_error), collapse = "")
       stop(sprintf(msg, vcov, class(model)[1]))
     }
   }
@@ -79,10 +82,8 @@ get_vcov <- function(model, vcov = NULL, conf_level = NULL, ...) {
     mat <- try(sandwich::vcovCL(model, cluster = vcov), silent = TRUE)
 
     if (!inherits(mat, "matrix")) {
-      msg <- paste0("Unable to extract a clustered variance-covariance matrix from model of class %s. ",
-        "You might be able to calculate a variance-covariance matrix for the model by using ",
-        "an external function, and then supply this matrix to modelsummary directly using the vcov argument.",
-        collapse = "")
+      msg <- paste0(c("Unable to extract a clustered variance-covariance matrix from model of class %s. ",
+        msg_vcov_error), collapse = "")
       stop(sprintf(msg, class(model)[1]))
     }
   }
@@ -97,10 +98,8 @@ get_vcov <- function(model, vcov = NULL, conf_level = NULL, ...) {
     }
 
     if (!inherits(mat, "matrix")) {
-      msg <- paste0("Unable to use the supplied function to a variance-covariance matrix from model of class %s. ",
-        "You might be able to calculate a variance-covariance matrix for the model by using ",
-        "an external function, and then supply this matrix to modelsummary directly using the vcov argument.",
-        collapse = "")
+      msg <- paste0(c("Unable to use the supplied function to extract a variance-covariance matrix from model of class %s. ",
+        msg_vcov_error), collapse = "")
       stop(sprintf(msg, class(model)[1]))
     }
   }
@@ -139,18 +138,15 @@ get_vcov <- function(model, vcov = NULL, conf_level = NULL, ...) {
       out <- data.frame(term = colnames(mat), std.error = out)
       msg <- paste0(
         "The `lmtest::coeftest` function does not seem to produce a valid result ",
-        "when applied to a model of class %s. Only `std.error` can be adjusted, ",
-        "but p values and confidence intervals might not be correct.", collapse = "")
+        "when applied to a model of class %s. Only the standard errors have been adjusted, ",
+        "but p-values and confidence intervals might not be correct.", collapse = "")
       warning(sprintf(msg, class(model)[1]))
       return(out)
     }
   }
 
-  msg <- paste0(
-    "Unable to extract a clustered variance-covariance matrix from model of class %s. ",
-    "You might be able to calculate a variance-covariance matrix for the model by using ",
-    "an external function, and then supply this matrix to modelsummary directly using the vcov argument.",
-    collapse = "")
+  msg <- paste0(c("Unable to extract a variance-covariance matrix from model of class %s. ",
+    msg_vcov_error), collapse = "")
   stop(sprintf(msg, class(model)[1]))
 }
 

--- a/R/get_vcov.R
+++ b/R/get_vcov.R
@@ -65,9 +65,11 @@ get_vcov <- function(model, vcov = NULL, conf_level = NULL, ...) {
     }
 
     if (!inherits(mat, "matrix")) {
-      msg <- "Unable to extract a variance-covariance matrix of type %s from model of class %s. The uncertainty estimates are unadjusted."
-      warning(sprintf(msg, vcov, class(model)[1]))
-      return(NULL)
+      msg <- paste0("Unable to extract a variance-covariance matrix of type %s from model of class %s. ",
+        "You might be able to calculate a variance-covariance matrix for the model by using ",
+        "an external function, and then supply this matrix to modelsummary directly using the vcov argument.",
+        collapse = "")
+      stop(sprintf(msg, vcov, class(model)[1]))
     }
   }
 
@@ -77,10 +79,11 @@ get_vcov <- function(model, vcov = NULL, conf_level = NULL, ...) {
     mat <- try(sandwich::vcovCL(model, cluster = vcov), silent = TRUE)
 
     if (!inherits(mat, "matrix")) {
-
-      msg <- "Unable to extract a clustered variance-covariance matrix from model of class %s. The uncertainty estimates are unadjusted."
-      warning(sprintf(msg, class(model)[1]))
-      return(NULL)
+      msg <- paste0("Unable to extract a clustered variance-covariance matrix from model of class %s. ",
+        "You might be able to calculate a variance-covariance matrix for the model by using ",
+        "an external function, and then supply this matrix to modelsummary directly using the vcov argument.",
+        collapse = "")
+      stop(sprintf(msg, class(model)[1]))
     }
   }
 
@@ -94,10 +97,11 @@ get_vcov <- function(model, vcov = NULL, conf_level = NULL, ...) {
     }
 
     if (!inherits(mat, "matrix")) {
-
-      msg <- "Unable to use function to extract a variance-covariance matrix from model of class %s. The uncertainty estimates are unadjusted."
-      warning(sprintf(msg, class(model)[1]))
-      return(NULL)
+      msg <- paste0("Unable to use the supplied function to a variance-covariance matrix from model of class %s. ",
+        "You might be able to calculate a variance-covariance matrix for the model by using ",
+        "an external function, and then supply this matrix to modelsummary directly using the vcov argument.",
+        collapse = "")
+      stop(sprintf(msg, class(model)[1]))
     }
   }
 
@@ -133,15 +137,21 @@ get_vcov <- function(model, vcov = NULL, conf_level = NULL, ...) {
 
       out <- sqrt(base::diag(mat))
       out <- data.frame(term = colnames(mat), std.error = out)
-      msg <- "The `lmtest::coeftest` function does not seem to produce a valid result when applied to a model of class %s. Only `std.error` can be adjusted."
+      msg <- paste0(
+        "The `lmtest::coeftest` function does not seem to produce a valid result ",
+        "when applied to a model of class %s. Only `std.error` can be adjusted, ",
+        "but p values and confidence intervals might not be correct.", collapse = "")
       warning(sprintf(msg, class(model)[1]))
       return(out)
     }
   }
 
-  msg <- "Unable to extract a clustered variance-covariance matrix from model of class %s. The uncertainty estimates are unadjusted."
-  warning(sprintf(msg, class(model)[1]))
-  return(NULL)
+  msg <- paste0(
+    "Unable to extract a clustered variance-covariance matrix from model of class %s. ",
+    "You might be able to calculate a variance-covariance matrix for the model by using ",
+    "an external function, and then supply this matrix to modelsummary directly using the vcov argument.",
+    collapse = "")
+  stop(sprintf(msg, class(model)[1]))
 }
 
 

--- a/tests/testthat/test-statistic_override.R
+++ b/tests/testthat/test-statistic_override.R
@@ -129,7 +129,7 @@ reference <- readRDS(file = "known_output/statistic-override.rds")
 
 
 test_that("bad function", {
-  expect_warning(modelsummary(models, statistic_override = na.omit))
+  expect_error(modelsummary(models, statistic_override = na.omit))
 })
 
 test_that("vector must be named", {

--- a/tests/testthat/test-supported.R
+++ b/tests/testthat/test-supported.R
@@ -100,14 +100,15 @@ test_that("ivreg::ivreg", {
   expect_is(tab, "data.frame")
   expect_true(nrow(tab) > 5)
 })
- 
+
 
 test_that("pscl::hurdle", {
+  testthat::skip_if_not_installed("pscl")
   set.seed(123)
   data("bioChemists", package = "pscl")
-  mod<- pscl::hurdle(formula = art ~ ., 
+  mod<- pscl::hurdle(formula = art ~ .,
                data = bioChemists, zero = "geometric")
-  tab <- modelsummary(mod, output="data.frame") 
+  tab <- modelsummary(mod, output="data.frame")
   expect_is(tab, "data.frame")
   expect_true(nrow(tab) > 25)
 })
@@ -176,8 +177,10 @@ test_that("lme4", {
   expect_true(nrow(tab) > 22)
 
   # sandwich does not support lmer
-  expect_warning(modelsummary(mod, vcov="robust"),
-                 regexp = "uncertainty estimates are unadjusted")
+  expect_error(modelsummary(mod, vcov="robust"),
+               regexp = "Unable to extract")
+  expect_error(modelsummary(mod, vcov=~subj),
+               regexp = "Unable to extract")
 })
 
 
@@ -187,7 +190,7 @@ test_that("lme4 with parameter's effects argument", {
   d <- as.data.frame(ChickWeight)
   colnames(d) <- c("y", "x", "subj", "tx")
   mod <- lmer(y ~ tx * x + (x | subj), data = d)
-  
+
   # all effects implicit
   tab <- modelsummary(mod, output="dataframe")
   tab <- tab[tab$part == "estimates",]

--- a/tests/testthat/test-vcov.R
+++ b/tests/testthat/test-vcov.R
@@ -85,16 +85,15 @@ test_that("lme4 and various warnings", {
   tab = modelsummary(models, output="dataframe", vcov=list("robust", "classical"))
   expect_s3_class(tab, "data.frame")
   expect_equal(ncol(tab), 5)
-  expect_warning(modelsummary(models, output="dataframe", vcov="robust"))
+  expect_error(modelsummary(models, output="dataframe", vcov="robust"), regexp = "Unable to extract")
   expect_warning(modelsummary(models, output="dataframe", vcov="classical"), NA)
   expect_warning(modelsummary(models, output="dataframe", vcov=list("robust", "classical")), NA)
   expect_warning(modelsummary(models[[2]], vcov=stats::vcov), regexp="Only.*error.*adjusted")
-  expect_warning(modelsummary(models, output="dataframe", vcov="robust"), regexp="are unadjusted")
 })
 
 
 test_that("robust character shortcuts", {
-  testthat::skip_if_not_installed("estimatr") 
+  testthat::skip_if_not_installed("estimatr")
 
   mod = lm(hp ~ mpg, mtcars)
   mod_estimatr = estimatr::lm_robust(hp ~ mpg, mtcars)
@@ -194,11 +193,11 @@ reference <- readRDS(file = "known_output/statistic-override.rds")
 
 
 test_that("bad function", {
-  expect_warning(modelsummary(models, vcov = na.omit))
+  expect_error(modelsummary(models, vcov = na.omit))
 })
 
 test_that("bad formula", {
-  expect_warning(modelsummary(models, vcov = ~bad))
+  expect_error(modelsummary(models, vcov = ~bad))
 })
 
 test_that("vector must be named", {


### PR DESCRIPTION
re #278

This is a first attempt, which changes all warnings to errors when `get_vcov` fails -- except when `coeftest` is only able to extract the standard errors. I updated that message a little bit as well, please check if that makes sense.

``` r
library(modelsummary)
library(lme4)
#> Loading required package: Matrix
d <- as.data.frame(ChickWeight)
colnames(d) <- c("y", "x", "subj", "tx")
mod_lmer <- lmer(y ~ tx * x + (x | subj), data = d)
modelsummary(mod_lmer, vcov="robust")
#> Error in get_vcov(model, vcov = vcov, conf_level = conf_level, ...): Unable to extract a variance-covariance matrix of type robust from model of class lmerMod. You might be able to calculate a variance-covariance matrix for the model by using an external function, and then supply this matrix to modelsummary directly using the vcov argument.
modelsummary(mod_lmer, vcov= ~subj)
#> Error in get_vcov(model, vcov = vcov, conf_level = conf_level, ...): Unable to extract a clustered variance-covariance matrix from model of class lmerMod. You might be able to calculate a variance-covariance matrix for the model by using an external function, and then supply this matrix to modelsummary directly using the vcov argument.
mod <- lm(mpg ~ cyl, data=mtcars)
modelsummary(mod, vcov=na.omit)
#> Error in get_vcov(model, vcov = vcov, conf_level = conf_level, ...): Unable to use the supplied function to a variance-covariance matrix from model of class lm. You might be able to calculate a variance-covariance matrix for the model by using an external function, and then supply this matrix to modelsummary directly using the vcov argument.
```

<sup>Created on 2021-05-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>