### PR TITLE
retain default "Std. Errors" output when supplying several vcov arguments

### DIFF
--- a/R/get_vcov.R
+++ b/R/get_vcov.R
@@ -201,6 +201,8 @@ get_vcov_type <- function(vcov) {
        }
     } else if (inherits(v, "formula")) {
       out <- paste("C:", as.character(v)[2])
+    } else if (is.null(v)) {
+      out <- NULL
     } else {
       out <- ""
     }


### PR DESCRIPTION
This addresses the remaining question in #279. When you supply `vcov = c(NULL, "iid")` or similar, then the standard error label will be the same as when using `vcov = NULL`. I think this should have no undesired side effects, as it only kicks in when the vcov list is not named, and when the value is actually NULL. The tests succeed, but maybe there are other concerns that I haven't thought about.

Example:

``` r
library("modelsummary")
library("fixest")
mod <- feols(hp ~ mpg + drat, mtcars, cluster = "vs")
modelsummary(mod, output = "markdown")
```

|             |    Model 1     |
|:------------|:--------------:|
| (Intercept) |    278.515     |
|             |    (20.573)    |
| mpg         |     -9.985     |
|             |    (4.110)     |
| drat        |     19.126     |
|             |    (32.644)    |
| Std. Errors | Clustered (vs) |

``` r
# this works as expected
modelsummary(mod, vcov = list(NULL), output = "markdown")
```

|             |    Model 1     |
|:------------|:--------------:|
| (Intercept) |    278.515     |
|             |    (20.573)    |
| mpg         |     -9.985     |
|             |    (4.110)     |
| drat        |     19.126     |
|             |    (32.644)    |
| Std. Errors | Clustered (vs) |

``` r
# now the default label also shows up here
modelsummary(mod, vcov = list(NULL, "iid"), output = "markdown")
```

|             |    Model 1     | Model 2  |
|:------------|:--------------:|:--------:|
| (Intercept) |    278.515     | 278.515  |
|             |    (20.573)    | (20.573) |
| mpg         |     -9.985     |  -9.985  |
|             |    (4.110)     | (4.110)  |
| drat        |     19.126     |  19.126  |
|             |    (32.644)    | (32.644) |
| Std. Errors | Clustered (vs) |   IID    |

<sup>Created on 2021-05-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>