### PR TITLE
error earlier when extractor functions fail

### DIFF
--- a/R/get_estimates.R
+++ b/R/get_estimates.R
@@ -39,6 +39,26 @@ get_estimates <- function(model, conf_level = .95, vcov = NULL, ...) {
         }
     }
 
+    if (!inherits(out, "data.frame")) {
+      stop(sprintf(
+        '`modelsummary could not extract the required information from a model
+of class "%s". The package tried a sequence of 2 helper functions to extract
+estimates:
+
+broom::tidy(model)
+parameters::parameters(model)
+
+To draw a table, one of these commands must return a `data.frame` with a
+column named "term". The `modelsummary` website explains how to summarize
+unsupported models or add support for new models yourself:
+
+https://vincentarelbundock.github.io/modelsummary/articles/modelsummary.html
+
+These errors messages were generated during extraction:
+%s',
+        class(model)[1], paste(warning_msg, collapse = "\n")))
+    }
+
     # tidy_custom
     out_custom <- tidy_custom(model)
     if (inherits(out_custom, "data.frame") && nrow(out_custom) > 0) {
@@ -88,24 +108,6 @@ get_estimates <- function(model, conf_level = .95, vcov = NULL, ...) {
     if (inherits(out, "data.frame")) {
         return(out)
     }
-
-    stop(sprintf(
-'`modelsummary could not extract the required information from a model
-of class "%s". The package tried a sequence of 2 helper functions to extract
-estimates:
-
-broom::tidy(model)
-parameters::parameters(model)
-
-To draw a table, one of these commands must return a `data.frame` with a
-column named "term". The `modelsummary` website explains how to summarize
-unsupported models or add support for new models yourself:
-
-https://vincentarelbundock.github.io/modelsummary/articles/modelsummary.html
-
-These errors messages were generated during extraction:
-%s',
-    class(model)[1], paste(warning_msg, collapse = "\n")))
 }
 
 


### PR DESCRIPTION
This should fix #296. The problem is that the `tidy` method fails (as it should), and `get_estimates_broom` returns a string as expected. But in `get_estimates`, there is a line `out$term` that forces `term` to be a character, although `out` might be a string. I think the simple solution is to move up the error message, such that `get_estimates` fails earlier. This might prevent other bugs, as the lines that concern `tidy_custom` also try to access columns of `out`, which, however, could be a character vector. All the tests pass, and I don't think this has any down sides.