### PR TITLE
missing p.values

### DIFF
--- a/R/format_estimates.R
+++ b/R/format_estimates.R
@@ -67,7 +67,9 @@ format_estimates <- function(
     }
     est$stars <- make_stars(est$p.value, stars)
     if (any(is.na(est$stars))) {
-      warning('p.values for some terms are missing.')
+      warning(paste0(
+        'p.values for some terms are missing and are not displayed. ',
+        'This is normal in some models, for instance lme4::lmer.'))
       est$stars[is.na(est$stars)] <- ""
     }
   }

--- a/R/format_estimates.R
+++ b/R/format_estimates.R
@@ -66,6 +66,10 @@ format_estimates <- function(
       stop('To use the `stars` argument, the `tidy` function must produce a column called "p.value"')
     }
     est$stars <- make_stars(est$p.value, stars)
+    if (any(is.na(est$stars))) {
+      warning('p.values for some terms are missing.')
+      est$stars[is.na(est$stars)] <- ""
+    }
   }
   if (isTRUE(is_star) && isFALSE(is_glue)) {
     estimate_glue[1] <- paste0(estimate_glue[1], "{stars}")

--- a/tests/testthat/test-stars.R
+++ b/tests/testthat/test-stars.R
@@ -114,3 +114,14 @@ test_that("custom stars", {
   expect_equal(truth, unname(raw[[5]][1:6]))
 
 })
+
+test_that("warning when p.value NA", {
+  mod <- lme4::lmer(mpg ~ drat + (1 | am), data = mtcars)
+  expect_warning(modelsummary(mod, output = "dataframe"), NA)
+  expect_warning(modelsummary(mod, output = "dataframe", stars = TRUE),
+                 "for some terms are missing")
+  expect_warning(r <- modelsummary(mod, output = "dataframe", estimate = "{stars}"),
+                 "for some terms are missing")
+  expect_equal(any(grepl("NA", r$`Model 1`)), FALSE)
+})
+


### PR DESCRIPTION
This is a simple change that is useful for lme4 models, where some terms don't have p.values. In this case, "NA" shows up in the table, and I'm not sure there's a good way to fix this. This solution changes `NA` to an empty string, and warns at the same time. If you think this is a good idea, I can add a test and the warning could probably be improved.

Before:

``` r
mod <- lme4::lmer(mpg ~ drat + (1 | am), data = mtcars)
modelsummary::msummary(mod, stars = TRUE, output = "markdown")
```

|                   |   Model 1   |
|:------------------|:-----------:|
| (Intercept)       |   -5.159    |
|                   |   (6.409)   |
| drat              | 7.045\*\*\* |
|                   |   (1.736)   |
| SD (Intercept)    |   1.156NA   |
| SD (Observations) |   2.109NA   |
| Num.Obs.          |     32      |

**Note:**
^^ \* p &lt; 0.1, \*\* p &lt; 0.05, \*\*\* p &lt; 0.01

<sup>Created on 2021-05-12 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

After:

``` r
mod <- lme4::lmer(mpg ~ drat + (1 | am), data = mtcars)
modelsummary::msummary(mod, stars = TRUE, output = "markdown")
#> Warning in format_estimates(est = msl[[i]]$tidy, fmt = fmt, estimate =
#> estimate[[i]], : p.values for some terms are missing.
```

|                   |   Model 1   |
|:------------------|:-----------:|
| (Intercept)       |   -5.159    |
|                   |   (6.409)   |
| drat              | 7.045\*\*\* |
|                   |   (1.736)   |
| SD (Intercept)    |    1.156    |
| SD (Observations) |    2.109    |
| Num.Obs.          |     32      |

**Note:**
^^ \* p &lt; 0.1, \*\* p &lt; 0.05, \*\*\* p &lt; 0.01

<sup>Created on 2021-05-12 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>