### PR TITLE
Consistent gof printing of cluster variables

### DIFF
--- a/R/glance_custom.R
+++ b/R/glance_custom.R
@@ -46,6 +46,39 @@ glance_custom_internal.fixest <- function(x, vcov_type = NULL, ...) {
   return(out)
 }
 
+#' @inherit glance_custom_internal
+#' @keywords internal
+glance_custom_internal.lm_robust <- function(x, vcov_type = NULL, ...) {
+    assert_dependency("estimatr")
+    out <- data.frame(row.names = "firstrow")
+    if (is.null(vcov_type) || !vcov_type %in% c("vector", "matrix", "function")) {
+        if (x$clustered) {
+            out[['vcov.type']] <- paste0("Clustered (", x$call$clusters, ")")
+        }
+    }
+    row.names(out) <- NULL
+    return(out)
+}
+#' @inherit glance_custom_internal
+#' @keywords internal
+glance_custom_internal.iv_robust <- glance_custom_internal.lm_robust
+
+#' @inherit glance_custom_internal
+#' @keywords internal
+glance_custom_internal.felm <- function(x, vcov_type = NULL, ...) {
+    assert_dependency("lfe")
+    out <- data.frame(row.names = "firstrow")
+    if (is.null(vcov_type) || !vcov_type %in% c("vector", "matrix", "function")) {
+        if (!is.null(x$clustervar)) {
+            cluster_vars = paste(names(x$clustervar), collapse = " & ")
+            out[['vcov.type']] <- paste0("Clustered (", cluster_vars, ")")
+        }
+    }
+    row.names(out) <- NULL
+    return(out)
+}
+
+
 ##' @inherit glance_custom
 ##' @noRd
 ##' @export


### PR DESCRIPTION
Current behaviour:

``` r
library(fixest)
library(lfe)
#> Loading required package: Matrix
library(estimatr)

mod_feols =   feols(hp ~ mpg + drat, mtcars, vcov = ~vs)
mod_felm =     felm(hp ~ mpg + drat |0 | 0 | vs, mtcars)
mod_rob = lm_robust(hp ~ mpg + drat, mtcars, se_type = 'stata', clusters = vs)

mods = list('feols' = mod_feols, 'felm' = mod_felm, 'lm_robust' = mod_rob)

library(modelsummary)

msummary(mods, gof_omit = 'Obs|R2|IC|Lik|se_type', output = 'markdown')
```

|             |     feols      |   felm   | lm_robust |
|:------------|:--------------:|:--------:|:---------:|
| (Intercept) |    278.515     | 278.515  |  278.515  |
|             |    (20.573)    | (20.573) | (20.573)  |
| mpg         |     -9.985     |  -9.985  |  -9.985   |
|             |    (4.110)     | (4.110)  |  (4.110)  |
| drat        |     19.126     |  19.126  |  19.126   |
|             |    (32.644)    | (32.644) | (32.644)  |
| Std. Errors | Clustered (vs) |          |           |

<sup>Created on 2021-08-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

With proposed change:

``` r
library(fixest)
library(lfe)
#> Loading required package: Matrix
library(estimatr)

mod_feols =   feols(hp ~ mpg + drat, mtcars, vcov = ~vs)
mod_felm =     felm(hp ~ mpg + drat |0 | 0 | vs, mtcars)
mod_rob = lm_robust(hp ~ mpg + drat, mtcars, se_type = 'stata', clusters = vs)

mods = list('feols' = mod_feols, 'felm' = mod_felm, 'lm_robust' = mod_rob)

library(modelsummary)

msummary(mods, gof_omit = 'Obs|R2|IC|Lik|se_type', output = 'markdown')
```

|             |     feols      |   felm   | lm_robust |
|:------------|:--------------:|:--------:|:---------:|
| (Intercept) |    278.515     | 278.515  |  278.515  |
|             |    (20.573)    | (20.573) | (20.573)  |
| mpg         |     -9.985     |  -9.985  |  -9.985   |
|             |    (4.110)     | (4.110)  |  (4.110)  |
| drat        |     19.126     |  19.126  |  19.126   |
|             |    (32.644)    | (32.644) | (32.644)  |
| Std. Errors | Clustered (vs) | Clustered (vs) | Clustered (vs) |

<sup>Created on 2021-08-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

