### PR TITLE
Std. error display and vcov args

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Improved `vcov` argument handling for `fixest` models (#357 by @grantmcdermott)
 * Fix display of `fixest::i()` variables and interactions (#361 by @grantmcdermott)
-* Consistent display of clustered SEs (#356 and #363 by @grantmcdermott)
+* Consistent display of clustered SEs (#356, #363 and #366 by @grantmcdermott)
 
 `datasummary_balance`:
 

--- a/R/get_estimates.R
+++ b/R/get_estimates.R
@@ -95,7 +95,7 @@ These errors messages were generated during extraction:
     }
 
     # fixest mods
-    fixest_mod = class(model) %in% c('fixest', 'fixest_multi')
+    fixest_mod = inherits(model, "fixest") || inherits(model, "fixest_multi")
 
     # vcov override
     flag1 <- !is.null(vcov)

--- a/R/get_estimates.R
+++ b/R/get_estimates.R
@@ -107,7 +107,7 @@ These errors messages were generated during extraction:
 
     if (flag1 && (flag2 || flag3 || flag4 || flag5)) {
 
-      # extract overriden estimates
+      # extract overridden estimates
       so <- get_vcov(
         model,
         vcov = vcov,

--- a/R/get_vcov.R
+++ b/R/get_vcov.R
@@ -276,7 +276,7 @@ get_vcov_type <- function(vcov) {
          out <- toupper(v)
        }
     } else if (inherits(v, "formula")) {
-      out <- paste("C:", as.character(v)[2])
+      out <- paste("by:", gsub("\\+", "\\&", gsub(":", "\\ & ", as.character(v)[2])))
     } else if (is.null(v)) {
       out <- NULL
     } else if (is.function(v)) {

--- a/R/glance_custom.R
+++ b/R/glance_custom.R
@@ -39,10 +39,14 @@ glance_custom_internal.fixest <- function(x, vcov_type = NULL, ...) {
   for (n in x$fixef_vars) {
     out[[paste('FE:', n)]] <- 'X'
   }
+  # if (vcov=="robust") {
+  #   vcov = NULL
+  # }
   if (is.null(vcov_type) || !vcov_type %in% c("vector", "matrix", "function")) {
     fvcov_type <- attr(fixest::coeftable(x), "type")
     if (utils::packageVersion("fixest") >= "0.10.0") {
-      fvcov_type <- gsub("^Clustered \\(", "by: ", gsub("\\)$", "", fvcov_type))
+      if (grepl("^Clustered", fvcov_type)) fvcov_type = gsub("\\)$", "", fvcov_type)
+      fvcov_type <- gsub("^Clustered \\(", "by: ", fvcov_type)
     } else {
       fvcov_type <- gsub("^Two-way|^Three-way|^Four-way", "", fvcov_type)
       fvcov_type <- gsub("^ \\(", "by: ", gsub("\\)$", "", fvcov_type))

--- a/R/glance_custom.R
+++ b/R/glance_custom.R
@@ -40,9 +40,14 @@ glance_custom_internal.fixest <- function(x, vcov_type = NULL, ...) {
     out[[paste('FE:', n)]] <- 'X'
   }
   if (is.null(vcov_type) || !vcov_type %in% c("vector", "matrix", "function")) {
-    fcov_type <- attr(fixest::coeftable(x), "type")
-    fcov_type <- gsub("Clustered \\(", "by: ", gsub("\\)$", "", fcov_type))
-    out[['vcov.type']] <- fcov_type
+    fvcov_type <- attr(fixest::coeftable(x), "type")
+    if (utils::packageVersion("fixest") >= "0.10.0") {
+      fvcov_type <- gsub("^Clustered \\(", "by: ", gsub("\\)$", "", fvcov_type))
+    } else {
+      fvcov_type <- gsub("^Two-way|^Three-way|^Four-way", "", fvcov_type)
+      fvcov_type <- gsub("^ \\(", "by: ", gsub("\\)$", "", fvcov_type))
+    }
+    out[['vcov.type']] <- fvcov_type
   }
   row.names(out) <- NULL
   return(out)

--- a/R/glance_custom.R
+++ b/R/glance_custom.R
@@ -40,7 +40,9 @@ glance_custom_internal.fixest <- function(x, vcov_type = NULL, ...) {
     out[[paste('FE:', n)]] <- 'X'
   }
   if (is.null(vcov_type) || !vcov_type %in% c("vector", "matrix", "function")) {
-    out[['vcov.type']] <- attr(fixest::coeftable(x), "type")
+    fcov_type <- attr(fixest::coeftable(x), "type")
+    fcov_type <- gsub("Clustered \\(", "by: ", gsub("\\)$", "", fcov_type))
+    out[['vcov.type']] <- fcov_type
   }
   row.names(out) <- NULL
   return(out)
@@ -53,7 +55,7 @@ glance_custom_internal.lm_robust <- function(x, vcov_type = NULL, ...) {
     out <- data.frame(row.names = "firstrow")
     if (is.null(vcov_type) || !vcov_type %in% c("vector", "matrix", "function")) {
         if (x$clustered) {
-            out[['vcov.type']] <- paste0("Clustered (", x$call$clusters, ")")
+            out[['vcov.type']] <- paste("by:", x$call$clusters)
         }
     }
     row.names(out) <- NULL
@@ -71,7 +73,7 @@ glance_custom_internal.felm <- function(x, vcov_type = NULL, ...) {
     if (is.null(vcov_type) || !vcov_type %in% c("vector", "matrix", "function")) {
         if (!is.null(x$clustervar)) {
             cluster_vars = paste(names(x$clustervar), collapse = " & ")
-            out[['vcov.type']] <- paste0("Clustered (", cluster_vars, ")")
+            out[['vcov.type']] <- paste("by:", cluster_vars)
         }
     }
     row.names(out) <- NULL
@@ -90,7 +92,7 @@ glance_custom_internal.MP <- function(x, vcov_type = NULL, ...) {
       } else {
         cluster_vars = x$DIDparams$idname
       }
-      out[['vcov.type']] <- paste0("Clustered (", cluster_vars, ")")
+      out[['vcov.type']] <- paste("by:", cluster_vars)
     }
   }
   row.names(out) <- NULL

--- a/R/glance_custom.R
+++ b/R/glance_custom.R
@@ -60,7 +60,8 @@ glance_custom_internal.lm_robust <- function(x, vcov_type = NULL, ...) {
     out <- data.frame(row.names = "firstrow")
     if (is.null(vcov_type) || !vcov_type %in% c("vector", "matrix", "function")) {
         if (x$clustered) {
-            out[['vcov.type']] <- paste("by:", x$call$clusters)
+            # out[['vcov.type']] <- paste("by:", x$call$clusters)
+            out[['se_type']] <- paste("by:", x$call$clusters)
         }
     }
     row.names(out) <- NULL

--- a/tests/testthat/test-get_vcov_type.R
+++ b/tests/testthat/test-get_vcov_type.R
@@ -1,18 +1,35 @@
 test_that("automatic standard errors labelling", {
     mod <- lm(hp ~ mpg, mtcars)
 
-    vcov <- list("iid", "robust", "stata", ~cyl, ~vs:am)
+    vcov <- list("iid", "robust", "stata", ~cyl, ~vs+am, ~vs:am)
     tab <- modelsummary(mod, vcov = vcov, output = "dataframe")
     expect_true("Std.Errors" %in% tab[[2]])
     expect_true("IID" %in% tab[[4]])
     expect_true("Robust" %in% tab[[5]])
     expect_true("Stata" %in% tab[[6]])
-    expect_true("C: cyl" %in% tab[[7]])
-    expect_true("C: vs:am" %in% tab[[8]])
+    expect_true("by: cyl" %in% tab[[7]])
+    expect_true("by: vs & am" %in% tab[[8]])
+    expect_true("by: vs & am" %in% tab[[9]])
 
     vcov <- list("iid", "robust")
     tab <- modelsummary(mod, vcov = vcov, output = "dataframe")
     expect_true("Std.Errors" %in% tab[[2]])
     expect_true("IID" %in% tab[[4]])
     expect_true("Robust" %in% tab[[5]])
+})
+
+test_that("consistent display of clustered SEs", {
+    skip_if_not_installed("fixest")
+    skip_if_not_installed("lfe")
+    library(fixest)
+    library(lfe)
+    mod_feols <- feols(mpg ~ wt, mtcars, vcov = ~ am + cyl)
+    mod_felm <- felm(mpg ~ wt | 0 | 0 | am + cyl, mtcars, cmethod = "cgm2")
+    gm <- modelsummary::gof_map
+    gm <- gm[gm$clean=="Std.Errors", ]
+    tab1 <- modelsummary(mod_feols, output = "dataframe", gof_map = gm)
+    tab2 <- modelsummary(mod_felm, output = "dataframe", gof_map = gm)
+    tab3 <- modelsummary(mod_feols, vcov = ~ am + cyl, output = "dataframe", gof_map = gm)
+    expect_equal(tab1, tab2)
+    expect_equal(tab1, tab3)
 })

--- a/tests/testthat/test-get_vcov_type.R
+++ b/tests/testthat/test-get_vcov_type.R
@@ -23,7 +23,11 @@ test_that("consistent display of clustered SEs", {
     skip_if_not_installed("lfe")
     library(fixest)
     library(lfe)
-    mod_feols <- feols(mpg ~ wt, mtcars, vcov = ~ am + cyl)
+    if (utils::packageVersion("fixest") >= "0.10.0") {
+        mod_feols <- feols(mpg ~ wt, mtcars, vcov = ~ am + cyl)
+    } else {
+        mod_feols <- feols(mpg ~ wt, mtcars, cluster = ~ am + cyl)
+    }
     mod_felm <- felm(mpg ~ wt | 0 | 0 | am + cyl, mtcars, cmethod = "cgm2")
     gm <- modelsummary::gof_map
     gm <- gm[gm$clean=="Std.Errors", ]


### PR DESCRIPTION
See: #360 (and especially https://github.com/vincentarelbundock/modelsummary/issues/360#issuecomment-900809668).

Checklist:

- [ ] Consistent SE names and/or dictionary (possibly beyond scope)
- [x] Consistent printing of clustered SEs (`by: var1 & var2`)
- [ ] Dynamic `vcov = "robust"` based on model object and call
- [ ] Infer default behaviour if `vcov = NULL`
- [ ] vcov whitelist (posssibly beyond scope)
