### PR TITLE
R2 excluded by default from performance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -87,6 +87,7 @@ Suggests:
 License: GPL-3
 Encoding: UTF-8
 Config/testthat/edition: 3
+Config/testthat/start-first: pkg-lme4
 LazyData: false
 Roxygen: list(markdown = TRUE)
 Language: en-US

--- a/R/get_gof.R
+++ b/R/get_gof.R
@@ -129,11 +129,17 @@ get_gof_parameters <- function(model, ...) {
     # stan models: r2_adjusted is veeeery slow
     if (inherits(model, "stanreg") ||
         inherits(model, "brmsfit") ||
-        inherits(model, "stanmvreg")) {
+        inherits(model, "stanmvreg") ||
+        inherits(model, "merMod")) {
       # this is the list of "common" metrics in `performance`
       # documentation, but their code includes R2_adj, which produces
       # a two-row glance and gives us issues.
-      metrics <- c("LOOIC", "WAIC", "R2", "RMSE")
+      msg <- '`modelsummary` uses the `performance` package to extract goodness-of-fit statistics from models of this class. You can specify the statistics you wish to compute by supplying a `metrics` argument to `modelsummary`, which will then push it forward to `performance`: `modelsummary(mod,metrics=c("RMSE","R2")` See `?performance::performance` for more information. Please note that some statistics are expensive to compute.'
+      rlang::warn( message = msg,
+                  .frequency = "once",
+                  .frequency_id = "performance_gof_expensive")
+
+      metrics <- c("RMSE", "LOOIC", "WAIC")
     } else {
       metrics <- "all"
     }

--- a/tests/testthat/test-missing.R
+++ b/tests/testthat/test-missing.R
@@ -4,6 +4,6 @@ requiet("lme4")
 test_that('random effects variance components do not have standard errors and produce "empty"', {
     mod <- lme4::lmer(mpg ~ hp + (1 | gear), mtcars)
     tab <- modelsummary(mod, output = "data.frame")
-    known <- c("(Intercept)", "(Intercept)", "hp", "hp", "SD (Intercept)", "SD (Observations)", "Num.Obs.", "R2 Marg.", "R2 Cond.", "AIC", "BIC", "ICC", "RMSE")
+    known <- c("(Intercept)", "(Intercept)", "hp", "hp", "SD (Intercept)", "SD (Observations)", "Num.Obs.", "RMSE")
     expect_equal(tab$term, known)
 })

--- a/tests/testthat/test-pkg-lme4.R
+++ b/tests/testthat/test-pkg-lme4.R
@@ -1,0 +1,18 @@
+requiet("lme4")
+
+test_that("performance metrics", {
+    N <- 1e4
+    dat <- data.frame(
+      x = rnorm(N),
+      y = rnorm(N),
+      k = factor(sample(1:50, N, replace = TRUE)),
+      m = factor(sample(1:1000, N, replace = TRUE)))
+    mod <- lmer(y ~ x + (1 | k) + (1 | m), data = dat)
+
+    expect_warning(modelsummary(mod, group = term + group ~ model))
+    tab1 <- modelsummary(mod, output = "data.frame", group = term + group ~ model)
+    tab2 <- modelsummary(mod, output = "data.frame", group = term + group ~ model, metrics = c("RMSE", "R2"))
+    expect_true("RMSE" %in% tab1$term)
+    expect_false("R2" %in% tab1$term)
+    expect_true(all(c("RMSE", "R2 Marg.", "R2 Cond.") %in% tab2$term))
+})


### PR DESCRIPTION
It is terribly slow. Give an informative warning about `metrics` argument