### PR TITLE
Add support for full sample summary to datasummary_balance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,12 @@ Authors@R: c(person("Vincent", "Arel-Bundock",
                    family = "McDermott",
                    role = "ctb",
                    email = "grantmcd@uoregon.edu",
-                   comment = c(ORCID = "0000-0001-7883-8573")))
+                   comment = c(ORCID = "0000-0001-7883-8573")),
+            person(given = "Lukas",
+                   family = "Wallrich",
+                   role = "ctb",
+                   email = "l.wallrich@bbk.ac.uk",
+                   comment = c(ORCID = "0000-0003-2121-5177")))
 URL: https://vincentarelbundock.github.io/modelsummary/
 BugReports: https://github.com/vincentarelbundock/modelsummary/issues/
 Depends:

--- a/man/datasummary_balance.Rd
+++ b/man/datasummary_balance.Rd
@@ -23,7 +23,8 @@ datasummary_balance(
 }
 \arguments{
 \item{formula}{a one-sided formula with the "condition" or "column" variable
-on the right-hand side.}
+on the right-hand side. ~1 can be used to show summary statistics for the
+full data set}
 
 \item{data}{A data.frame (or tibble). If this data includes columns called
 "blocks", "clusters", and/or "weights", the "estimatr" package will consider
@@ -94,8 +95,9 @@ the scenes. Examples include:
 }}
 }
 \description{
-Balance table: Summary statistics for different subsets of the data (e.g.,
-control and treatment groups)
+Creates balance tables with summary statistics for different subsets of the
+data (e.g., control and treatment groups). It can also be used to create
+summary tables for full data sets.
 }
 \section{Global Options}{
 

--- a/tests/testthat/test-datasummary_balance.R
+++ b/tests/testthat/test-datasummary_balance.R
@@ -155,6 +155,18 @@ test_that('more than two conditions', {
   expect_equal(dim(tab), c(14, 8))
 })
 
+test_that('no conditions - grand summary', {
+    # fails on devtools::check_win_devel
+    skip_on_cran()
+    tmp <- mtcars
+    tmp$cyl <- factor(tmp$cyl)
+    tmp$vs <- as.logical(tmp$vs)
+    tab <- datasummary_balance(~1, tmp, output = 'dataframe', dinm = FALSE)
+    expect_s3_class(tab, 'data.frame')
+    expect_equal(dim(tab), c(15, 4))
+    tab <- suppressWarnings(datasummary_balance(~1, tmp, output = 'dataframe', dinm = TRUE))
+    expect_equal(dim(tab), c(15, 4))
+})
 
 test_that('single numeric', {
   tmp <- mtcars[, c('am', 'mpg')]


### PR DESCRIPTION
In line with #434, I've now added support for full sample summaries to `datasummary_balance` when using ~1 as the grouping formula. I have also added a new test that covers this case and adjusted the documentation.

Please let me know if you spot any potential issues, or if there is something else you would like to see changed / cleaned up. I believe you can easily squash the commits when merging - but let me know if you'd prefer me to finally learn how to do that on my end :)