### PR TITLE
Update glance_custom example for fixest IV reg

### DIFF
--- a/vignettes/modelsummary.Rmd
+++ b/vignettes/modelsummary.Rmd
@@ -1070,7 +1070,7 @@ rm("tidy_custom.lm")
 
 ## `fixest`: Fixed effects and instrumental variable regression
 
-One common use-case for `glance_custom` is to include additional goodness-of-fit statistics. For example, in an instrumental variable estimation computed by the `fixest` package, we may want to include an IV-Wald statistic:
+One common use-case for `glance_custom` is to include additional goodness-of-fit statistics. For example, in an instrumental variable estimation computed by the `fixest` package, we may want to include an IV-Wald statistic for the first-stage regression of each endogenous regressor:
 
 ```{r, message=FALSE}
 library(fixest)
@@ -1087,7 +1087,10 @@ mod <- feols(y ~ x1 | fe | x_endo_1 + x_endo_2 ~ x_inst_1 + x_inst_2, base)
 
 # custom extractor function returns a one-row data.frame (or tibble)
 glance_custom.fixest <- function(x) {
-  tibble("IV Wald" = fitstat(x, "ivwald")[[1]]$stat)
+  tibble(
+    "Wald (x_endo_1)" = fitstat(x, "ivwald")[[1]]$stat,
+    "Wald (x_endo_2)" = fitstat(x, "ivwald")[[2]]$stat
+  )
 }
 
 # draw table


### PR DESCRIPTION
Closes #488.

Make clear in the description that the Wald statistic refers to the first-stage regressions and include them for *both* endogenous regressors.

The solution below is more flexible (with respect to non-IV estimations and the number of endogenous regressors) but so convoluted that I feel it might distract from the basic usage. 
```r
glance_custom.fixest <- function(x) {
  if (!is.null(x$iv)) {
    fitstat(x, "ivwald") |> 
      map_dfr("stat") |> 
      rename_with(~str_replace(.x, ".*::(.*)", "Wald \\(\\1\\)"))
  }
}
```