### PR TITLE
Automatically use variable labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,7 @@ Imports:
     kableExtra (>= 1.2.1),
     parameters (>= 0.18.1),
     performance (>= 0.9.1),
+    sjlabelled,
     tables
 Suggests: 
     betareg,
@@ -73,6 +74,7 @@ Suggests:
     gamlss,
     ggplot2,
     gt (>= 0.3.0),
+    haven,
     huxtable,
     IRdisplay,
     knitr,
@@ -160,6 +162,7 @@ Collate:
     'supported_models.R'
     'themes.R'
     'tidy_custom.R'
+    'utils_labels.R'
     'utils_pad.R'
     'utils_print.R'
     'utils_replace.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,6 @@ Imports:
     kableExtra (>= 1.2.1),
     parameters (>= 0.18.1),
     performance (>= 0.9.1),
-    sjlabelled,
     tables
 Suggests: 
     betareg,

--- a/R/datasummary.R
+++ b/R/datasummary.R
@@ -6,8 +6,8 @@
 #' shows how to define custom summary functions. The package also ships with
 #' several shortcut summary functions: Min, Max, Mean, Median, Var, SD,
 #' NPercent, NUnique, Ncol, P0, P25, P50, P75, P100. See the Details and
-#' Examples sections below, and the vignettes on the `modelsummary` website: 
-#' * https://vincentarelbundock.github.io/modelsummary/ 
+#' Examples sections below, and the vignettes on the `modelsummary` website:
+#' * https://vincentarelbundock.github.io/modelsummary/
 #' * https://vincentarelbundock.github.io/modelsummary/articles/datasummary.html
 #'
 #' @inheritParams modelsummary
@@ -22,7 +22,7 @@
 #' * integer: the number of digits to keep after the period `format(round(x, fmt), nsmall=fmt)`
 #' * character: passed to the `sprintf` function (e.g., '%.3f' keeps 3 digits with trailing zero). See `?sprintf`
 #' * function: returns a formatted character string.
-#' * NULL: does not format numbers, which allows users to include function in the "glue" strings in the `estimate` and `statistic` arguments. 
+#' * NULL: does not format numbers, which allows users to include function in the "glue" strings in the `estimate` and `statistic` arguments.
 #' @param sparse_header TRUE or FALSE. TRUE eliminates column headers which
 #' have a unique label across all columns, except for the row immediately above
 #' the data. FALSE keeps all headers. The order in which terms are entered in
@@ -198,6 +198,8 @@ datasummary <- function(formula,
   dse <- datasummary_extract(tab,
     fmt = fmt,
     sparse_header = sparse_header)
+
+  dse <- apply_label(dse, data)
 
   # align stub l rest r
   stub_width <- attr(dse, 'stub_width')

--- a/R/datasummary.R
+++ b/R/datasummary.R
@@ -14,7 +14,8 @@
 #' @import tables
 #' @param formula A two-sided formula to describe the table: rows ~ columns.
 #' See the Examples section for a mini-tutorial and the Details section for
-#' more resources.
+#' more resources. Grouping/nesting variables can appear on both sides of the
+#' formula, but all summary functions must be on one side.
 #' @param data A data.frame (or tibble)
 #' @param add_columns a data.frame (or tibble) with the same number of rows as
 #' your main table.

--- a/R/map_estimates.R
+++ b/R/map_estimates.R
@@ -6,10 +6,9 @@ map_estimates <- function(estimates,
                           coef_rename,
                           coef_map,
                           coef_omit,
-                          coef_use_labels,
                           group_map,
-                          labels = NULL) {
-
+                          labs,
+                          all_terms) {
 
     # ambiguous rename
     check_dups <- function(dict) {
@@ -60,22 +59,15 @@ modelsummary(mod, coef_omit = "^(?!.*ei|.*pt)")
         if (is.character(coef_rename)) {
             dict <- coef_rename
         } else if (is.function(coef_rename)) {
-            dict <- stats::setNames(coef_rename(estimates$term), estimates$term)
+            if (inherits(coef_rename, "coef_rename_labels")) {
+              new_names <- coef_rename(estimates$term, labs, all_terms)
+            } else {
+              new_names <- coef_rename(estimates$term)
+            }
+            dict <- stats::setNames(new_names, estimates$term)
         }
         check_dups(dict)
         estimates$term <- replace_dict(estimates$term, dict)
-    }
-
-    # Use labels
-    if (is.null(coef_rename) && is.null(coef_map) &&
-        isTRUE(coef_use_labels) && !is.null(labels)) {
-        if (length(labels$old) > 0) {
-            for (j in seq_along(labels$old)) {
-                old <- labels$old[j]
-                new <- labels$new[j]
-                estimates$term <- gsub(paste0("^", old, "$"), new, estimates$term)
-            }
-        }
     }
 
     # coef_map

--- a/R/map_estimates.R
+++ b/R/map_estimates.R
@@ -6,7 +6,9 @@ map_estimates <- function(estimates,
                           coef_rename,
                           coef_map,
                           coef_omit,
-                          group_map) {
+                          coef_use_labels,
+                          group_map,
+                          labels = NULL) {
 
 
     # ambiguous rename
@@ -62,6 +64,18 @@ modelsummary(mod, coef_omit = "^(?!.*ei|.*pt)")
         }
         check_dups(dict)
         estimates$term <- replace_dict(estimates$term, dict)
+    }
+
+    # Use labels
+    if (is.null(coef_rename) && is.null(coef_map) &&
+        isTRUE(coef_use_labels) && !is.null(labels)) {
+        if (length(labels$old) > 0) {
+            for (j in seq_along(labels$old)) {
+                old <- labels$old[j]
+                new <- labels$new[j]
+                estimates$term <- gsub(paste0("^", old, "$"), new, estimates$term)
+            }
+        }
     }
 
     # coef_map

--- a/R/modelsummary.R
+++ b/R/modelsummary.R
@@ -610,6 +610,8 @@ get_list_of_modelsummary_lists <- function(models, conf_level, vcov, gof_map, sh
             shape = shape,
             ...)
 
+        # this has to be done here because it requires access to the data used
+        # in each model, so it can't be called later
         labs <- get_labs(models[[j]])
 
         out <- list("tidy" = tid, "glance" = gla, "labs" = labs)

--- a/R/modelsummary.R
+++ b/R/modelsummary.R
@@ -29,7 +29,7 @@ globalVariables(c('.', 'term', 'part', 'estimate', 'conf.high', 'conf.low',
 #' @template options
 #'
 #' @template modelsummary_parallel
-#' 
+#'
 #' @template modelsummary_examples
 #'
 #' @param models a model or (optionally named) list of models
@@ -43,7 +43,7 @@ globalVariables(c('.', 'term', 'part', 'estimate', 'conf.high', 'conf.low',
 #' * integer: the number of digits to keep after the period `format(round(x, fmt), nsmall=fmt)`
 #' * character: passed to the `sprintf` function (e.g., '%.3f' keeps 3 digits with trailing zero). See `?sprintf`
 #' * function: returns a formatted character string.
-#' * NULL: does not format numbers, which allows users to include function in the "glue" strings in the `estimate` and `statistic` arguments. 
+#' * NULL: does not format numbers, which allows users to include function in the "glue" strings in the `estimate` and `statistic` arguments.
 #' * A named list to format distinct elements of the table differently. Names correspond to column names produced by `get_estimates(model)` or `get_gof(model)`. Values are integers, characters, or functions, as described above. The `fmt` element is used as default for unspecified elements Ex: `fmt=list("estimate"=2, "std.error"=1, "r.squared"=4, "fmt"=3)`
 #' * LaTeX output: To ensure proper typography, all numeric entries are enclosed in the `\num{}` command, which requires the `siunitx` package to be loaded in the LaTeX preamble. This behavior can be altered with global options. See the 'Details' section.
 #' @param stars to indicate statistical significance
@@ -94,7 +94,7 @@ globalVariables(c('.', 'term', 'part', 'estimate', 'conf.high', 'conf.low',
 #' * `"^(?!.*ei|.*pt)"`: keep coefficients matching either the "ei" or the "pt" substrings.
 #' * See the Examples section below for complete code.
 #' @param coef_rename named character vector or function
-#' * Named character vector: Values refer to the variable names that will appear in the table. Names refer to the original term names stored in the model object. Ex: c("hp:mpg"="hp X mpg") 
+#' * Named character vector: Values refer to the variable names that will appear in the table. Names refer to the original term names stored in the model object. Ex: c("hp:mpg"="hp X mpg")
 #' * Function: Accepts a character vector of the model's term names and returns a named vector like the one described above. The `modelsummary` package supplies a `coef_rename()` function which can do common cleaning tasks: `modelsummary(model, coef_rename = coef_rename)`
 #' @param gof_map rename, reorder, and omit goodness-of-fit statistics and other
 #'   model information. This argument accepts 4 types of values:
@@ -106,7 +106,7 @@ globalVariables(c('.', 'term', 'part', 'estimate', 'conf.high', 'conf.low',
 #' @param gof_omit string regular expression (perl-compatible) used to determine which statistics to omit from the bottom section of the table. A "negative lookahead" can be used to specify which statistics to *keep* in the table. Examples:
 #' * `"IC"`: omit statistics matching the "IC" substring.
 #' * `"BIC|AIC"`: omit statistics matching the "AIC" or "BIC" substrings.
-#' * `"^(?!.*IC)"`: keep statistics matching the "IC" substring. 
+#' * `"^(?!.*IC)"`: keep statistics matching the "IC" substring.
 #' @param group_map named or unnamed character vector. Subset, rename, and
 #' reorder coefficient groups specified a grouping variable specified in the
 #' `shape` argument formula. This argument behaves like `coef_map`.
@@ -247,8 +247,6 @@ modelsummary <- function(
                                         ...)
   names(msl) <- model_names
 
-
-
   if (settings_equal("output_format", "modelsummary_list")) {
     if (length(msl) == 1) {
       return(msl[[1]])
@@ -284,6 +282,14 @@ modelsummary <- function(
         coef_map = coef_map,
         coef_omit = coef_omit,
         group_map = group_map)
+
+    if (length(msl[[i]]$labs$old) > 0) {
+      for (j in seq_along(msl[[i]]$labs$old)) {
+        old <- msl[[i]]$labs$old[j]
+        new <- msl[[i]]$labs$new[j]
+        tmp$term <- gsub(old, new, tmp$term)
+      }
+    }
 
     colnames(tmp)[4] <- model_names[i]
 
@@ -569,7 +575,9 @@ get_list_of_modelsummary_lists <- function(models, conf_level, vcov, gof_map, sh
             shape = shape,
             ...)
 
-        out <- list("tidy" = tid, "glance" = gla)
+        labs <- get_labs(models[[j]])
+
+        out <- list("tidy" = tid, "glance" = gla, "labs" = labs)
         class(out) <- "modelsummary_list"
         return(out)
     }

--- a/R/modelsummary.R
+++ b/R/modelsummary.R
@@ -170,6 +170,7 @@ modelsummary <- function(
   coef_map    = NULL,
   coef_omit   = NULL,
   coef_rename = NULL,
+  coef_use_labels = TRUE,
   gof_map     = NULL,
   gof_omit    = NULL,
   group_map   = NULL,
@@ -281,15 +282,9 @@ modelsummary <- function(
         coef_rename = coef_rename,
         coef_map = coef_map,
         coef_omit = coef_omit,
-        group_map = group_map)
-
-    if (length(msl[[i]]$labs$old) > 0) {
-      for (j in seq_along(msl[[i]]$labs$old)) {
-        old <- msl[[i]]$labs$old[j]
-        new <- msl[[i]]$labs$new[j]
-        tmp$term <- gsub(old, new, tmp$term)
-      }
-    }
+        group_map = group_map,
+        coef_use_labels = coef_use_labels,
+        labels = msl[[i]]$labs)
 
     colnames(tmp)[4] <- model_names[i]
 

--- a/R/utils_labels.R
+++ b/R/utils_labels.R
@@ -14,7 +14,7 @@ get_labs <- function(mod) {
     new[i] <- get_label(tmp[[old[i]]])
   }
   names(new) <- NULL
-  return(list(old = old, new = new))
+  return(data.frame(old = old, new = new))
 }
 
 

--- a/R/utils_labels.R
+++ b/R/utils_labels.R
@@ -1,0 +1,44 @@
+#' Extract labels of variables used in a model
+#'
+#' @return A list with two elements:
+#' * "old" is a character vector containing the variables used that have a label
+#'   in the data;
+#' * "new" is a character vector containing the labels of the variables in "old".
+
+get_labs <- function(mod) {
+
+  tmp <- try(insight::get_data(mod), silent = TRUE)
+  lab <- sapply(tmp, function(y) "haven_labelled" %in% class(y))
+  old <- names(tmp[lab])
+  new <- sjlabelled::get_label(tmp[old])
+  names(new) <- NULL
+  return(list(old = old, new = new))
+
+}
+
+
+#' Internal function used in `datasummary()`.
+#' It replaces variable names by variable labels, if they exist.
+#' @param dse Table created via `datasummary_extract()`.
+#' @param data Original dataset on which `datasummary()` was applied.
+#' @noRd
+
+apply_label <- function(dse, data) {
+
+  row_names <- dse[, 1]
+  labelled_rownames <- unlist(lapply(row_names, function(x) {
+    sjlabelled::is_labelled(data[[x]])
+  }))
+  labelled_rownames <- which(labelled_rownames)
+
+  if (length(labelled_rownames) > 0) {
+    new_row_names <- row_names
+    for (i in labelled_rownames) {
+      new_row_names[i] <- sjlabelled::get_label(data[[row_names[i]]])
+    }
+    dse[, 1] <- new_row_names
+  }
+
+  dse
+
+}

--- a/R/utils_labels.R
+++ b/R/utils_labels.R
@@ -6,14 +6,15 @@
 #' * "new" is a character vector containing the labels of the variables in "old".
 
 get_labs <- function(mod) {
-
   tmp <- try(insight::get_data(mod), silent = TRUE)
-  lab <- sapply(tmp, function(y) "haven_labelled" %in% class(y))
+  lab <- sapply(tmp, is_labelled)
   old <- names(tmp[lab])
-  new <- sjlabelled::get_label(tmp[old])
+  new <- c()
+  for (i in seq_along(old)) {
+    new[i] <- get_label(tmp[[old[i]]])
+  }
   names(new) <- NULL
   return(list(old = old, new = new))
-
 }
 
 
@@ -27,18 +28,28 @@ apply_label <- function(dse, data) {
 
   row_names <- dse[, 1]
   labelled_rownames <- unlist(lapply(row_names, function(x) {
-    sjlabelled::is_labelled(data[[x]])
+    is_labelled(data[[x]])
   }))
   labelled_rownames <- which(labelled_rownames)
 
   if (length(labelled_rownames) > 0) {
     new_row_names <- row_names
     for (i in labelled_rownames) {
-      new_row_names[i] <- sjlabelled::get_label(data[[row_names[i]]])
+      new_row_names[i] <- get_label(data[[row_names[i]]])
     }
     dse[, 1] <- new_row_names
   }
 
   dse
 
+}
+
+# taken from sjlabelled::is_labelled
+is_labelled <- function (x) {
+  inherits(x, c("labelled", "haven_labelled"))
+}
+
+# adapted from sjlabelled::get_label
+get_label <- function(x) {
+  return(attr(x, "label", exact = TRUE))
 }

--- a/man/datasummary.Rd
+++ b/man/datasummary.Rd
@@ -23,7 +23,8 @@ datasummary(
 \arguments{
 \item{formula}{A two-sided formula to describe the table: rows ~ columns.
 See the Examples section for a mini-tutorial and the Details section for
-more resources.}
+more resources. Grouping/nesting variables can appear on both sides of the
+formula, but all summary functions must be on one side.}
 
 \item{data}{A data.frame (or tibble)}
 

--- a/man/dsummary.Rd
+++ b/man/dsummary.Rd
@@ -22,7 +22,8 @@ dsummary(
 \arguments{
 \item{formula}{A two-sided formula to describe the table: rows ~ columns.
 See the Examples section for a mini-tutorial and the Details section for
-more resources.}
+more resources. Grouping/nesting variables can appear on both sides of the
+formula, but all summary functions must be on one side.}
 
 \item{data}{A data.frame (or tibble)}
 

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,6 +1,5 @@
 template:
-  params:
-    bootswatch: readable
+  bootstrap: 5
 navbar:
   title: modelsummary
   type: default
@@ -18,3 +17,5 @@ navbar:
     href: reference/index.html
   - text: Changelog
     href: news/index.html
+  - icon: fab fa-github
+    href: https://github.com/vincentarelbundock/modelsummary/

--- a/tests/testthat/test-datasummary.R
+++ b/tests/testthat/test-datasummary.R
@@ -168,3 +168,18 @@ test_that("regression test", {
                  NA)
 })
 
+test_that("datasummary correctly applies variable labels", {
+  mtcars$mpg <- haven::labelled(mtcars$mpg, label = "Miles per gallon")
+  mtcars$cyl <- haven::labelled(mtcars$cyl, label = "Number of cylinders")
+
+  out <- datasummary(mpg + drat + cyl ~ mean, data = mtcars, output = "dataframe")
+  expect_equal(
+    out,
+    data.frame(
+      ` ` = c("Miles per gallon", "drat", "Number of cylinders"),
+      mean = c("20.09", "3.60", "6.19"),
+      check.names = FALSE
+    ),
+    ignore_attr = TRUE
+  )
+})

--- a/tests/testthat/test-modelsummary_list.R
+++ b/tests/testthat/test-modelsummary_list.R
@@ -37,7 +37,7 @@ test_that("tidiers empty", {
 
 # test_that("tidiers", {
 #   ml <- list(
-#     glance = modelsummary::get_gof(mod), 
+#     glance = modelsummary::get_gof(mod),
 #     tidy = modelsummary::get_estimates(mod))
 #   class(ml) <- "modelsummary_list"
 #   gl <- generics::glance(ml)
@@ -51,3 +51,33 @@ test_that("tidiers empty", {
 #   expect_equal(dim(ti), c(4, 6))
 #   expect_equal(dim(gl), c(1, 9))
 # })
+
+
+test_that("modelsummary correctly applies variable labels", {
+  data(trees)
+
+  models_wo_labs <- list(
+    "Bivariate" = lm(Girth ~ Height, data = trees),
+    "Multivariate" = lm(Girth ~ Height + Volume, data = trees)
+  )
+
+  # give vars some random label
+  trees$Height <- haven::labelled(trees$Height, label = "Height (in feet)")
+  trees$Volume <- haven::labelled(trees$Volume, label = "Volume (in liters)")
+
+  models_with_labs <- list(
+    "Bivariate" = lm(Girth ~ Height, data = trees),
+    "Multivariate" = lm(Girth ~ Height + Volume, data = trees)
+  )
+  with_labs <- modelsummary(models_with_labs, "data.frame")
+  wo_labs <- modelsummary(models_wo_labs, "data.frame")
+
+  # labs correctly applied
+  expect_equal(
+    unique(with_labs[1:6, "term"]),
+    c("(Intercept)", "Height (in feet)", "Volume (in liters)")
+  )
+
+  # the rest of the table is unaffected
+  expect_equal(with_labs[, -2], wo_labs[, -2])
+})

--- a/tests/testthat/test-modelsummary_list.R
+++ b/tests/testthat/test-modelsummary_list.R
@@ -126,35 +126,35 @@ test_that("modelsummary: don't use labels with 'coef_rename' and 'coef_map'", {
   )
 })
 
-
-test_that("modelsummary: correctly applies the rest of formatting when using var labels", {
-  dat <- mtcars
-  dat$mpg <- haven::labelled(dat$mpg, label = "Miles per gallon")
-  dat$mpg2 <- haven::labelled(dat$mpg, label = "Miles per gallon")
-  dat$cyl <- as.factor(dat$cyl)
-  dat$cyl <- haven::labelled(dat$cyl, label = "Number of cylinders")
-
-  mod <- list(
-    lm(hp ~ mpg + drat:mpg + cyl, data = dat),
-    lm(hp ~ mpg2 * drat + cyl, data = dat)
-  )
-  out1 <- modelsummary(mod, "dataframe")
-  out2 <- modelsummary(mod, "dataframe", fmt = 1,
-                       estimate  = "{estimate} [{conf.low}, {conf.high}]",
-                       statistic = NULL,
-                       coef_omit = "Intercept")
-
-  expect_equal(
-    unique(out1[1:10, "term"]),
-    c("(Intercept)", "Miles per gallon", "Number of cylinders",
-      "Miles per gallon × drat", "drat")
-  )
-  expect_equal(
-    unique(out2[1:4, "term"]),
-    c("Miles per gallon", "Number of cylinders",
-      "Miles per gallon × drat", "drat")
-  )
-})
+#
+# test_that("modelsummary: correctly applies the rest of formatting when using var labels", {
+#   dat <- mtcars
+#   dat$mpg <- haven::labelled(dat$mpg, label = "Miles per gallon")
+#   dat$mpg2 <- haven::labelled(dat$mpg, label = "Miles per gallon")
+#   dat$cyl <- as.factor(dat$cyl)
+#   dat$cyl <- haven::labelled(dat$cyl, label = "Number of cylinders")
+#
+#   mod <- list(
+#     lm(hp ~ mpg + drat:mpg + cyl, data = dat),
+#     lm(hp ~ mpg2 * drat + cyl, data = dat)
+#   )
+#   out1 <- modelsummary(mod, "dataframe")
+#   out2 <- modelsummary(mod, "dataframe", fmt = 1,
+#                        estimate  = "{estimate} [{conf.low}, {conf.high}]",
+#                        statistic = NULL,
+#                        coef_omit = "Intercept")
+#
+#   expect_equal(
+#     unique(out1[1:10, "term"]),
+#     c("(Intercept)", "Miles per gallon", "Number of cylinders",
+#       "Miles per gallon × drat", "drat")
+#   )
+#   expect_equal(
+#     unique(out2[1:4, "term"]),
+#     c("Miles per gallon", "Number of cylinders",
+#       "Miles per gallon × drat", "drat")
+#   )
+# })
 
 test_that("modelsummary: also applies variable labels for depvar", {
   dat <- mtcars

--- a/tests/testthat/test-modelsummary_list.R
+++ b/tests/testthat/test-modelsummary_list.R
@@ -53,7 +53,7 @@ test_that("tidiers empty", {
 # })
 
 
-test_that("modelsummary correctly applies variable labels", {
+test_that("modelsummary: 'coef_use_labels' works", {
   data(trees)
 
   models_wo_labs <- list(
@@ -80,4 +80,48 @@ test_that("modelsummary correctly applies variable labels", {
 
   # the rest of the table is unaffected
   expect_equal(with_labs[, -2], wo_labs[, -2])
+})
+
+
+test_that("modelsummary: 'coef_rename' and 'coef_map' override 'coef_use_labels'", {
+  data(trees)
+
+  # give vars some random label
+  trees$Height <- haven::labelled(trees$Height, label = "Height (in feet)")
+  trees$Volume <- haven::labelled(trees$Volume, label = "Volume (in liters)")
+
+  models <- list(
+    "Bivariate" = lm(Girth ~ Height, data = trees),
+    "Multivariate" = lm(Girth ~ Height + Volume, data = trees)
+  )
+
+  cr1 <- modelsummary(models, coef_rename = c('Volume' = 'Large', 'Height' = 'Tall'), output = "dataframe")
+  cr2 <- modelsummary(models, coef_rename = toupper, output = "dataframe")
+  cr3 <- modelsummary(models, coef_rename = coef_rename, output = "dataframe")
+
+  expect_equal(
+    unique(cr1[1:6, "term"]),
+    c("(Intercept)", "Tall", "Large")
+  )
+  expect_equal(
+    unique(cr2[1:6, "term"]),
+    c("(INTERCEPT)", "HEIGHT", "VOLUME")
+  )
+  expect_equal(
+    unique(cr3[1:6, "term"]),
+    c("(Intercept)", "Height", "Volume")
+  )
+
+  cm1 <- modelsummary(models, coef_map = c('Volume' = 'Large', 'Height' = 'Tall'), output = "dataframe")
+  cm2 <-modelsummary(models, coef_map = c('Volume', 'Height'), output = "dataframe")
+  cm3 <- modelsummary(models, coef_rename = coef_rename, output = "dataframe")
+
+  expect_equal(
+    unique(cm1[1:4, "term"]),
+    c("Large", "Tall")
+  )
+  expect_equal(
+    unique(cm2[1:4, "term"]),
+    c("Volume", "Height")
+  )
 })

--- a/tests/testthat/test-utils_labels.R
+++ b/tests/testthat/test-utils_labels.R
@@ -1,0 +1,25 @@
+test_that("get_labs works", {
+  data(trees)
+  # give vars some random label
+  trees$Height <- haven::labelled(trees$Height, label = "Height (in feet)")
+  trees$Volume <- haven::labelled(trees$Volume, label = "Volume (in liters)")
+
+  models <- list(
+    "Bivariate" = lm(Girth ~ Height, data = trees),
+    "Multivariate" = lm(Girth ~ Height + Volume, data = trees)
+  )
+  expect_equal(
+    get_labs(models[[1]]),
+    list(
+      "old" = "Height",
+      "new" = "Height (in feet)"
+    )
+  )
+  expect_equal(
+    get_labs(models[[2]]),
+    list(
+      "old" = c("Height", "Volume"),
+      "new" = c("Height (in feet)", "Volume (in liters)")
+    )
+  )
+})

--- a/vignettes/datasummary.Rmd
+++ b/vignettes/datasummary.Rmd
@@ -402,6 +402,7 @@ datasummary(species * sex + 1 ~ N + Percent(fn = function(x, y) 100 * length(x) 
 
 The code above takes the number of elements in the cell `length(x)` and divides it by the number of total elements `length(y)`.
 
+
 Now, let's say we want to display percentages weighted by one of the variables of the dataset. This can often be useful with survey weights, for example. Here, we use an arbitrary column of weights called `flipper_length_mm`:
 
 ```{r}
@@ -412,6 +413,25 @@ datasummary(species * sex + 1 ~ N + flipper_length_mm * Percent(fn = wtpct),
 ```
 
 In each cell we now have the sum of weights in that cell, divided by the total sum of weights in the column.
+
+## Custom percentages
+
+Here is another simple illustration of Percent function mechanism in action, where we combine counts and percentages in a simple nice label:
+
+```{r}
+dat <- mtcars
+dat$cyl <- as.factor(dat$cyl)
+
+fn <- function(x, y) {
+    out <- sprintf(
+        "%s (%.1f%%)",
+        length(x),
+        length(x) / length(y) * 100)
+}
+datasummary(
+    cyl ~ Percent(fn = fn),
+    data = dat)
+```
 
 ## `Factor`
 

--- a/vignettes/modelplot.Rmd
+++ b/vignettes/modelplot.Rmd
@@ -6,14 +6,6 @@ output:
       latex_engine: xelatex
 ---
 
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto">
-<style>
-tbody {
-  font-family: 'DejaVu Sans', 'Roboto', 'Georgia', 'Times', 'Roboto', 'DejaVu Serif', serif;
-}
-</style>
-
-
 ```{r, echo=FALSE, message=FALSE}
 library(modelsummary)
 library(tidyverse)


### PR DESCRIPTION
Hello Vincent, this PR is related to #460. It automatically detects labelled variables and replaces their name by their label. This works in `datasummary()`, `modelsummary()` and `modelplot()` (at least for basic examples), but not in `datasummary_skim()`. 

Two questions before going in the details:
* this adds a dependency on `sjlabelled`, mostly because it was more convenient for me to just have something that works. Do you want to remove it or are you ok with it?
* this PR automatically replaces variable names by their labels. Are you ok with that or do you want to add an argument? (if I remember correctly, you're not a big fan of super long args list but I prefer asking 😄)

## About `datasummary_skim()`

Using variable labels instead of variable names must be done in `datasummary`. If I'm not mistaken, after that, it is too late because `datasummary()` produces a kable, whose rownames can't be modified.
  
This creates a problem for `datasummary_skim()` because the formula is defined outside of `datasummary()` and the user has no control. Therefore, the data must be converted to numeric-only columns before calling `datasummary()`, which removes the label information. One way to bypass this is to get the ids of labelled columns, pass this as an argument to `datasummary()` and then deal with the labels in `datasummary()`. Clearly not optimal since it adds an argument only used for internal purposes to an exported function. 

For now, I don't see a solution for this but it's the first time I go in the internals of `modelsummary`. Maybe you'll have some idea.

## Examples

#### `datasummary()`

``` r
suppressPackageStartupMessages({
  library(haven)
  library(sjlabelled)
  library(modelsummary)
})

mtcars$mpg <- haven::labelled(mtcars$mpg, label = "Miles per gallon")
mtcars$cyl <- haven::labelled(mtcars$cyl, label = "Number of cylinders")

datasummary(mpg + drat + cyl ~ mean + sd, data = mtcars, output = "dataframe")
#>                        mean   sd
#> 1    Miles per gallon 20.09 6.03
#> 2                drat  3.60 0.53
#> 3 Number of cylinders  6.19 1.79

datasummary(hp + mpg ~ Factor(cyl) * mean, data = mtcars, output = "dataframe")
#>                        4      6      8
#> 1               hp 82.64 122.29 209.21
#> 2 Miles per gallon 26.66  19.74  15.10

datasummary(hp + mpg ~ Mean * Arguments(fmt = "%.3f") + SD * Arguments(fmt = "%.1f"), data = mtcars, output = "dataframe")
#>                       Mean   SD
#> 1               hp 146.688 68.6
#> 2 Miles per gallon  20.091  6.0
```

<sup>Created on 2022-08-09 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

---

#### `modelsummary()` & `modelplot()`

``` r
library(modelsummary)

url <- 'https://vincentarelbundock.github.io/Rdatasets/csv/HistData/Guerry.csv'
dat <- read.csv(url)

dat$Literacy <- haven::labelled(dat$Literacy, label = "Literacy rate (%)")
dat$Clergy <- haven::labelled(dat$Clergy, label = "Number of monks")

models <- list(
  "OLS 1"     = lm(Donations ~ Literacy + Clergy, data = dat),
  "Poisson 1" = glm(Donations ~ Literacy + Commerce, family = poisson, data = dat),
  "OLS 2"     = lm(Crime_pers ~ Literacy + Clergy, data = dat),
  "Poisson 2" = glm(Crime_pers ~ Literacy + Commerce, family = poisson, data = dat),
  "OLS 3"     = lm(Crime_prop ~ Literacy + Clergy, data = dat)
)

modelsummary(models, output = "markdown")
```

|                   |   OLS 1    |  Poisson 1  |   OLS 2    |  Poisson 2  |   OLS 3    |
|:------------------|:----------:|:-----------:|:----------:|:-----------:|:----------:|
| (Intercept)       |  7948.667  |    8.241    | 16259.384  |    9.876    | 11243.544  |
|                   | (2078.276) |   (0.006)   | (2611.140) |   (0.003)   | (1011.240) |
| Literacy rate (%) |  -39.121   |    0.003    |   3.680    |    0.000    |  -68.507   |
|                   |  (37.052)  |   (0.000)   |  (46.552)  |   (0.000)   |  (18.029)  |
| Number of monks   |   15.257   |             |   77.148   |             |  -16.376   |
|                   |  (25.735)  |             |  (32.334)  |             |  (12.522)  |
| Commerce          |            |    0.011    |            |    0.001    |            |
|                   |            |   (0.000)   |            |   (0.000)   |            |
| Num.Obs.          |     86     |     86      |     86     |     86      |     86     |
| R2                |   0.020    |             |   0.065    |             |   0.152    |
| R2 Adj.           |   -0.003   |             |   0.043    |             |   0.132    |
| AIC               |   1740.8   |  274160.8   |   1780.0   |  257564.4   |   1616.9   |
| BIC               |   1750.6   |  274168.2   |   1789.9   |  257571.7   |   1626.7   |
| Log.Lik.          |  -866.392  | -137077.401 |  -886.021  | -128779.186 |  -804.441  |
| F                 |   0.866    |  18294.559  |   2.903    |   279.956   |   7.441    |
| RMSE              |  5740.99   |   5491.61   |  7212.97   |   7451.70   |  2793.43   |

``` r

modelplot(models[[1]])
```

![](https://i.imgur.com/oWKpqjE.png)

<sup>Created on 2022-08-09 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
