### PR TITLE
Add github icon on website and update to Bootstrap 5

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -18,3 +18,5 @@ navbar:
     href: reference/index.html
   - text: Changelog
     href: news/index.html
+  - icon: fab fa-github
+    href: https://github.com/vincentarelbundock/modelsummary/

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,6 +1,5 @@
 template:
-  params:
-    bootswatch: readable
+  bootstrap: 5
 navbar:
   title: modelsummary
   type: default


### PR DESCRIPTION
However for the search box, since you're using bootstrap 3 (I think) it's not that easy to implement (https://pkgdown.r-lib.org/articles/search.html) but it should be automatic if you switch to bootstrap 5 in the future