### PR TITLE
Add arguments to rename polynomials with `coef_rename()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: Create beautiful and customizable tables to summarize several
     RTF, JPG, or PNG. Tables can easily be embedded in 'Rmarkdown' or 'knitr'
     dynamic documents. Details can be found in Arel-Bundock (2022)
     <doi:10.18637/jss.v103.i01>.
-Version: 2.1.1
+Version: 2.1.1.1
 Authors@R: c(person("Vincent", "Arel-Bundock", 
                    email = "vincent.arel-bundock@umontreal.ca", 
                    role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # News 
 
+## Development
+
+* `coef_rename()` gets a `poly=TRUE` argument to rename `poly(x, 2)`-style coefficients. Thanks to @mccarthy-m-g for code contribution #778.
+
 ## 2.1.1
 
 * Documentation improvements

--- a/R/coef_rename.R
+++ b/R/coef_rename.R
@@ -8,8 +8,6 @@
 #' @param factor_name boolean remove the "factor()" label and the name of the
 #' variable
 #' @param poly boolean remove the "poly()" label and function arguments
-#' @param poly_name boolean remove the "poly()" label, function arguments, and
-#' the name of the variable
 #' @param backticks boolean remove backticks
 #' @param titlecase boolean convert to title case
 #' @param underscore boolean replace underscores by spaces
@@ -28,7 +26,6 @@ coef_rename <- function(x,
                        factor = TRUE,
                        factor_name = TRUE,
                        poly = TRUE,
-                       poly_name = TRUE,
                        backticks = TRUE,
                        titlecase = TRUE,
                        underscore = TRUE,
@@ -41,9 +38,7 @@ coef_rename <- function(x,
     out <- gsub("factor\\((.*)\\)", "\\1 ", out)
   }
 
-  if (isTRUE(poly_name)) {
-    out <- gsub("poly\\(.*\\)", "^", out)
-  } else if (isTRUE(poly)) {
+  if (isTRUE(poly)) {
     out <- gsub("poly\\(([^,]*),.*\\)", "\\1^", out)
   }
 

--- a/R/coef_rename.R
+++ b/R/coef_rename.R
@@ -7,6 +7,9 @@
 #' @param factor boolean remove the "factor()" label
 #' @param factor_name boolean remove the "factor()" label and the name of the
 #' variable
+#' @param poly boolean remove the "poly()" label and function arguments
+#' @param poly_name boolean remove the "poly()" label, function arguments, and
+#' the name of the variable
 #' @param backticks boolean remove backticks
 #' @param titlecase boolean convert to title case
 #' @param underscore boolean replace underscores by spaces
@@ -24,6 +27,8 @@
 coef_rename <- function(x,
                        factor = TRUE,
                        factor_name = TRUE,
+                       poly = TRUE,
+                       poly_name = TRUE,
                        backticks = TRUE,
                        titlecase = TRUE,
                        underscore = TRUE,
@@ -34,6 +39,12 @@ coef_rename <- function(x,
     out <- gsub("factor\\(.*\\)", "", out)
   } else if (isTRUE(factor)) {
     out <- gsub("factor\\((.*)\\)", "\\1 ", out)
+  }
+
+  if (isTRUE(poly_name)) {
+    out <- gsub("poly\\(.*\\)", "^", out)
+  } else if (isTRUE(poly)) {
+    out <- gsub("poly\\(([^,]*),.*\\)", "\\1^", out)
   }
 
   if (isTRUE(underscore)) {

--- a/man/coef_rename.Rd
+++ b/man/coef_rename.Rd
@@ -8,6 +8,8 @@ coef_rename(
   x,
   factor = TRUE,
   factor_name = TRUE,
+  poly = TRUE,
+  poly_name = TRUE,
   backticks = TRUE,
   titlecase = TRUE,
   underscore = TRUE,
@@ -21,6 +23,11 @@ coef_rename(
 
 \item{factor_name}{boolean remove the "factor()" label and the name of the
 variable}
+
+\item{poly}{boolean remove the "poly()" label and function arguments}
+
+\item{poly_name}{boolean remove the "poly()" label, function arguments, and
+the name of the variable}
 
 \item{backticks}{boolean remove backticks}
 

--- a/man/coef_rename.Rd
+++ b/man/coef_rename.Rd
@@ -9,7 +9,6 @@ coef_rename(
   factor = TRUE,
   factor_name = TRUE,
   poly = TRUE,
-  poly_name = TRUE,
   backticks = TRUE,
   titlecase = TRUE,
   underscore = TRUE,
@@ -25,9 +24,6 @@ coef_rename(
 variable}
 
 \item{poly}{boolean remove the "poly()" label and function arguments}
-
-\item{poly_name}{boolean remove the "poly()" label, function arguments, and
-the name of the variable}
 
 \item{backticks}{boolean remove backticks}
 


### PR DESCRIPTION
This PR updates `coef_rename()` to handle polynomial coefficients created by the `poly()` function, similar to how the function currently handles factors. Here's some reprex code to check the new functionality out:

```r
x <- list(
    lm(mpg ~ poly(cyl, 2) + drat + disp, data = mtcars),
    lm(hp ~ poly(cyl, 2, raw = TRUE) + drat + disp, data = mtcars)
)

# Results in polynomial names of the form '^1', '^2', etc.
modelsummary(dvnames(x), coef_rename = coef_rename)

# Results in polynomial names of the form 'Cyl^1', 'Cyl^2', etc.
modelsummary(dvnames(x), coef_rename = \(.x) coef_rename(.x, poly_name = FALSE))
```

Note that I didn't update `NEWS` or add any tests yet (I'm unfamiliar with `tinytest`, so I'm unsure how to go about it).