### PR TITLE
fix: use flextable::hline instead of flextable::border

### DIFF
--- a/R/themes.R
+++ b/R/themes.R
@@ -112,7 +112,7 @@ theme_ms_flextable <- function(tab, output_format, hrule, ...) {
   # horizontal rule to separate coef/gof
   if (!is.null(hrule)) {
     for (pos in hrule) {
-      out <- flextable::border(out, i = pos, border.top = officer::fp_border())
+      out <- flextable::hline(out, i = pos - 1, border = flextable::fp_border_default())
     }
   }
   return(out)


### PR DESCRIPTION
Hello

This issue https://github.com/davidgohel/flextable/issues/693 led me to take a look at the “modelsummary” source code. I propose a small modification to solve the problem by using `hline()` instead of `border()` *(1)*.

*(1) The `hline` instructions are well managed by flextable, but the `border` function requires careful adjustment to avoid overlapping borders.*

- fix the border issue when printing to Word
- ensure usage of the default settings for color and width of the line

KR
David




````
library(modelsummary)
library(flextable)
set_flextable_defaults(
  border.color = "purple"
)
modlm <- lm(gear ~ mpg + wt, data = mtcars)
res <- modelsummary(
  modlm,
  stars = TRUE,
  out = "flextable"
)
# print(res, preview = "docx")
````