### PR TITLE
fix: remove dead fixest branch in get_vcov, add multi-way cluster test

### DIFF
--- a/R/get_vcov.R
+++ b/R/get_vcov.R
@@ -37,27 +37,18 @@ get_vcov.default <- function(model, vcov = NULL, ...) {
     )
   } else if (isTRUE(checkmate::check_formula(vcov))) {
     dots[["cluster"]] <- vcov
-    if (inherits(model, "fixest")) {
-      out <- try(
-        insight::get_varcov(
-          model,
-          vcov = "vcovCL",
-          vcov_args = dots,
-          component = "all"
-        ),
-        silent = TRUE
-      )
-    } else {
-      out <- try(
-        insight::get_varcov(
-          model,
-          vcov = "vcovCL",
-          vcov_args = dots,
-          component = "all"
-        ),
-        silent = TRUE
-      )
-    }
+    # Note: for fixest models, sanitize_vcov() already converts formula vcov
+    # to a matrix via stats::vcov(model, vcov = formula), so this path is
+    # only reached by non-fixest models.
+    out <- try(
+      insight::get_varcov(
+        model,
+        vcov = "vcovCL",
+        vcov_args = dots,
+        component = "all"
+      ),
+      silent = TRUE
+    )
     if (inherits(out, "try-error")) {
       msg <- attr(out, "condition")$message
       if (grepl("Unable to extract", msg)) {

--- a/inst/tinytest/test-pkg-fixest.R
+++ b/inst/tinytest/test-pkg-fixest.R
@@ -150,3 +150,21 @@ dat <- transform(mtcars, carb_carb = carb)
 mod <- feols(mpg ~ hp | carb_carb, data = dat)
 k <- modelsummary(mod, output = "latex")
 expect_false(grepl("FE: carb_carb", k))
+
+# fixest multi-way clustering formula: SEs match fixest native vcov
+mod <- feols(mpg ~ hp + drat, mtcars)
+se_native <- sqrt(diag(vcov(mod, vcov = ~vs + am)))
+tab <- modelsummary(
+  mod,
+  vcov = ~vs + am,
+  gof_map = NA,
+  estimate = "std.error",
+  statistic = NULL,
+  output = "dataframe"
+)
+se_ms <- as.numeric(tab[["(1)"]])
+expect_equivalent(se_ms, se_native, ignore_attr = TRUE)
+
+# fixest formula vcov label for multi-way clustering
+tab <- modelsummary(mod, vcov = ~vs + am, output = "dataframe")
+expect_true("by: vs & am" %in% tab[["(1)"]])


### PR DESCRIPTION
## Changes

****: Remove dead `if (inherits(model, "fixest"))` branch.

The fixest and non-fixest branches had identical code. For fixest models, `sanitize_vcov()` already converts formula vcov to a matrix via `stats::vcov(model, vcov = formula)` (see `process_fixest_vcov` in `sanitize_vcov.R:91`), so the formula path in `get_vcov` is never reached by fixest models. This cleanup removes the redundant branch and adds a clarifying comment.

****: Add test for fixest multi-way clustering formula vcov.

Verifies that `modelsummary(feols_model, vcov = ~vs + am)` produces SEs matching fixest's native `vcov(model, vcov = ~vs + am)`, and that the label displays as `by: vs & am`.

## Testing

- `test-pkg-fixest.R`: 22 tests OK
- `test-vcov.R`: 18 tests OK (stops at missing `estimatr` package, unrelated)
- `test-get_vcov_type.R`: 9 tests OK (stops at missing `lfe` package, unrelated)