### PR TITLE
docs: clarify formula vcov behavior for fixest models, add clustered SE example

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,13 @@
 - Tests compare output files by content rather than raw bytes, so the
   `test-output-file.R` assertions no longer fail on Windows because of
   CRLF line endings. Thanks to @raffaelemancuso for pull request \#969.
+- Documentation: one-sided `vcov` formulas are passed to
+  `sandwich::vcovCL` for most models, but `fixest` models use `fixest`’s
+  own `stats::vcov()` method, which supports multi-way clustering such
+  as `~cluster1 + cluster2`. The two produce different standard errors,
+  so the previous text was misleading. A clustered standard error
+  example was also added. Thanks to @LeonidasZhak for pull request
+  \#959.
 
 ## 2.6.0
 

--- a/NEWS.qmd
+++ b/NEWS.qmd
@@ -11,6 +11,7 @@ format: gfm
 * `datasummary()` with `output = "tinytable"` now correctly displays non-sparse subheaders when `sparse_header = FALSE`. Fixes Issue \#955. Thanks to @raffaelemancuso.
 * Model packages are now attached on `future` workers, so goodness-of-fit rows are no longer silently dropped when a multi-worker `future` plan is active. Thanks to @raffaelemancuso for pull request \#971.
 * Tests compare output files by content rather than raw bytes, so the `test-output-file.R` assertions no longer fail on Windows because of CRLF line endings. Thanks to @raffaelemancuso for pull request \#969.
+* Documentation: one-sided `vcov` formulas are passed to `sandwich::vcovCL` for most models, but `fixest` models use `fixest`'s own `stats::vcov()` method, which supports multi-way clustering such as `~cluster1 + cluster2`. The two produce different standard errors, so the previous text was misleading. A clustered standard error example was also added. Thanks to @LeonidasZhak for pull request \#959.
 
 ## 2.6.0
 

--- a/R/modelsummary.R
+++ b/R/modelsummary.R
@@ -270,6 +270,9 @@ globalVariables(c(
 #'     "Stata Corp" = "stata",
 #'     "Newey Lewis & the News" = "NeweyWest"))
 #'
+#' # clustered standard errors with a formula
+#' modelsummary(models, vcov = ~ Height)
+#'
 #' # fmt
 #' mod <- lm(mpg ~ hp + drat + qsec, data = mtcars)
 #'

--- a/man-roxygen/modelsummary_details.R
+++ b/man-roxygen/modelsummary_details.R
@@ -24,8 +24,10 @@
 #' uncertainty estimates and simply report the default standard errors stored
 #' in the model object.
 #'
-#' One-sided formulas such as `~clusterid` are passed to the `sandwich::vcovCL`
-#' function.
+#' One-sided formulas such as `~clusterid` are passed to `sandwich::vcovCL`
+#' for most model types. For `fixest` models, the formula is passed to
+#' `fixest`'s native `stats::vcov()` method, which supports multi-way
+#' clustering (e.g., `~cluster1 + cluster2`).
 #'
 #' Matrices and functions producing variance-covariance matrices are first
 #' passed to `lmtest`. If this does not work, `modelsummary` attempts to take

--- a/man/modelsummary.Rd
+++ b/man/modelsummary.Rd
@@ -314,8 +314,10 @@ NULL, "classical", "iid", and "constant" are aliases which do not modify
 uncertainty estimates and simply report the default standard errors stored
 in the model object.
 
-One-sided formulas such as \code{~clusterid} are passed to the \code{sandwich::vcovCL}
-function.
+One-sided formulas such as \code{~clusterid} are passed to \code{sandwich::vcovCL}
+for most model types. For \code{fixest} models, the formula is passed to
+\code{fixest}'s native \code{stats::vcov()} method, which supports multi-way
+clustering (e.g., \code{~cluster1 + cluster2}).
 
 Matrices and functions producing variance-covariance matrices are first
 passed to \code{lmtest}. If this does not work, \code{modelsummary} attempts to take
@@ -560,6 +562,9 @@ modelsummary(
   vcov = list(
     "Stata Corp" = "stata",
     "Newey Lewis & the News" = "NeweyWest"))
+
+# clustered standard errors with a formula
+modelsummary(models, vcov = ~ Height)
 
 # fmt
 mod <- lm(mpg ~ hp + drat + qsec, data = mtcars)

--- a/man/msummary.Rd
+++ b/man/msummary.Rd
@@ -314,8 +314,10 @@ NULL, "classical", "iid", and "constant" are aliases which do not modify
 uncertainty estimates and simply report the default standard errors stored
 in the model object.
 
-One-sided formulas such as \code{~clusterid} are passed to the \code{sandwich::vcovCL}
-function.
+One-sided formulas such as \code{~clusterid} are passed to \code{sandwich::vcovCL}
+for most model types. For \code{fixest} models, the formula is passed to
+\code{fixest}'s native \code{stats::vcov()} method, which supports multi-way
+clustering (e.g., \code{~cluster1 + cluster2}).
 
 Matrices and functions producing variance-covariance matrices are first
 passed to \code{lmtest}. If this does not work, \code{modelsummary} attempts to take
@@ -560,6 +562,9 @@ modelsummary(
   vcov = list(
     "Stata Corp" = "stata",
     "Newey Lewis & the News" = "NeweyWest"))
+
+# clustered standard errors with a formula
+modelsummary(models, vcov = ~ Height)
 
 # fmt
 mod <- lm(mpg ~ hp + drat + qsec, data = mtcars)


### PR DESCRIPTION
## Changes

1. **Clarify formula vcov behavior for fixest models**: The Details section previously stated that one-sided formulas are passed to `sandwich::vcovCL`, but for `fixest` models they're passed to `fixest`'s native `stats::vcov()` method, which supports multi-way clustering (e.g., `~cluster1 + cluster2`). Updated both the roxygen source (`man-roxygen/modelsummary_details.R`) and generated Rd files.

2. **Add clustered SE example**: Added `modelsummary(models, vcov = ~ Height)` to the examples section showing formula-based clustered standard errors.

## Files changed
- `R/modelsummary.R` — added clustered SE example to roxygen examples
- `man-roxygen/modelsummary_details.R` — clarified formula vcov behavior for fixest
- `man/modelsummary.Rd` — regenerated from roxygen (manual Rd edits to avoid Unicode corruption)
- `man/msummary.Rd` — same

## Validation
- `tools::checkRd()` — clean on both Rd files
- Complementary to PR #958 (dead code removal + tests), not overlapping

## Notes
- This PR only touches documentation. The Rd files were edited manually rather than regenerated via `devtools::document()` to avoid a roxygen2 Unicode encoding issue that corrupts smart quotes in the references section.