### PR TITLE
fix: typos in roxygen docs, error messages, and vignettes

### DIFF
--- a/R/datasummary_skim.R
+++ b/R/datasummary_skim.R
@@ -14,7 +14,7 @@
 #' @import data.table
 #' @param type String. Variables to summarize: "all", "numeric", "categorical", "dataset"
 #' @param by Character vector of grouping variables to compute statistics over.
-#' @param fun_numeric Named list of funtions to apply to each numeric column of `data`. If `fun_numeric` includes "Histogram" or "Density", inline plots are inserted. This argument is only used when `type="numeric"` or `"all"`.
+#' @param fun_numeric Named list of functions to apply to each numeric column of `data`. If `fun_numeric` includes "Histogram" or "Density", inline plots are inserted. This argument is only used when `type="numeric"` or `"all"`.
 #'
 #' @template kableExtra2tinytable
 #' @template citation

--- a/R/fmt_factory.R
+++ b/R/fmt_factory.R
@@ -240,7 +240,7 @@ fmt_statistic <- function(..., default = 3) {
 fmt_term <- function(..., default = 3) {
   args <- utils::modifyList(list(...), list("default" = default))
   if (!isTRUE(checkmate::check_list(args, names = "named"))) {
-    msg <- "All arguments of the `fmt_statistic()` function must be named."
+    msg <- "All arguments of the `fmt_term()` function must be named."
     insight::format_error(msg)
   }
 

--- a/R/get_gof.R
+++ b/R/get_gof.R
@@ -1,11 +1,11 @@
-#' Extract goodness-of-fit statistics a tidy format.
+#' Extract goodness-of-fit statistics in a tidy format.
 #'
 #' A unified approach to extract results from a wide variety of models. 
 #'
 #' @param vcov_type string vcov type to add at the bottom of the table
 #' @inheritParams get_estimates
 #' @inheritParams modelsummary
-#' @returns A dataframe with the goodness-o-fit statistics.
+#' @returns A dataframe with the goodness-of-fit statistics.
 #'          The `backend` attribute indicates the backend used to extract them.
 #'          Moreover, for some models `get_gof` attaches useful attributes to the output. 
 #'          You can access this information by calling the `attributes` function `attributes(get_estimates(model))`.

--- a/R/gof_map.R
+++ b/R/gof_map.R
@@ -74,10 +74,10 @@ gof_map_build <- function() {
   sigma,                     Sigma,              3, TRUE,
   srmr,                      SRMR,               0, TRUE,
   statistic,                 Statistics,         3, TRUE,
+  tli,                       TLI,                0, TRUE,
   wu.hausman,                Wu-Hausman,         3, TRUE,
   wu.hausman.p,              Wu-Hausman (p),     3, TRUE,
-  statistic,                 Statistics,         3, TRUE,
-  tli,                       TLI,                0, TRUE,'
+'
   out <- utils::read.csv(
     text = text,
     colClasses = c("character", "character", "numeric", "logical", "NULL")

--- a/R/modelsummary.R
+++ b/R/modelsummary.R
@@ -167,7 +167,7 @@ globalVariables(c(
 #'   - `term : response + statistic ~ model`: term and group id in a single column
 #'   - `term ~ response`
 #' * String: "cbind", "rbind", "rcollapse"
-#'   - "cbind": side-by-side models with autmoatic spanning column headers to group models (`tinytable` only feature).
+#'   - "cbind": side-by-side models with automatic spanning column headers to group models (`tinytable` only feature).
 #'   - "rbind" or "rcollapse": "panels" or "stacks" of regression models.
 #'   -  the `models` argument must be a (potentially named) nested list of models.
 #'     + Unnamed nested list with 2 panels: `list(list(model1, model2), list(model3, model4))`

--- a/R/sanity_checks.R
+++ b/R/sanity_checks.R
@@ -363,7 +363,7 @@ sanity_ds_right_handed_formula <- function(formula) {
   termlabels <- labels(stats::terms(formula))
   if (length(termlabels) > 1) {
     stop(
-      "The 'datasummary_table' function only accepts a single right-hand side variable of type factor, character, or logical. If you do not want to transform your variable in the original data, you can wrap it in a Factor() call: datasummary_balance(~Factor(x), data). the name of your variablePlease visit the `modelsummary` website to learn how to build your own, more complex, Table 1. It's easy, I promise! https://modelsummary.com/datasummary.html"
+      "The 'datasummary_table' function only accepts a single right-hand side variable of type factor, character, or logical. If you do not want to transform your variable in the original data, you can wrap it in a Factor() call: datasummary_balance(~Factor(x), data). Please visit the `modelsummary` website to learn how to build your own, more complex, Table 1. It's easy, I promise! https://modelsummary.com/datasummary.html"
     )
   }
 }

--- a/vignettes/appearance.qmd
+++ b/vignettes/appearance.qmd
@@ -69,7 +69,7 @@ modelsummary(models) |>
     style_tt(i = 3:4, j = 2, background = "teal", color = "white", bold = TRUE)
 ```
 
-Now, we create a descriptive statistics table with `datasummary()`. That table includes an emptyr row, which we fill with density plots using the `plot_tt()` function from `tinytable`:
+Now, we create a descriptive statistics table with `datasummary()`. That table includes an empty row, which we fill with density plots using the `plot_tt()` function from `tinytable`:
 
 ```{r}
 Density <- function(x) ""

--- a/vignettes/modelsummary.qmd
+++ b/vignettes/modelsummary.qmd
@@ -74,7 +74,7 @@ modelsummary(models, output = "latex")
 modelsummary(models, output = "markdown")
 ```
 
-If you to customize the appearance of your table using external tools like `gt`, `kableExtra`, `flextable`, or `huxtable`, you can type:
+If you want to customize the appearance of your table using external tools like `gt`, `kableExtra`, `flextable`, or `huxtable`, you can type:
 
 ```{r, eval=FALSE}
 modelsummary(models, output = "gt")
@@ -1178,7 +1178,7 @@ modelsummary(mod, "html", coef_omit = "qsec|gear")
 ```
 
 
-Return to nomal:
+Return to normal:
 
 ```{r}
 rm(list = c("glance_custom.glm", "glance_custom.lm"))
@@ -1202,7 +1202,7 @@ mtcars %>%
 
 ## Bootstrap
 
-Users often want to use estimates or standard errors that have been obtained using a custom strategy. To achieve this in an automated and replicable way, it can be useful to use the `tidy_custom` strategy described above in the "Cutomizing Existing Models" section. 
+Users often want to use estimates or standard errors that have been obtained using a custom strategy. To achieve this in an automated and replicable way, it can be useful to use the `tidy_custom` strategy described above in the "Customizing Existing Models" section. 
 
 For example, we can use the `modelr` package to draw 500 resamples of a dataset, and compute bootstrap standard errors by taking the standard deviation of estimates computed in all of those resampled datasets. To do this, we defined `tidy_custom.lm` function that will automatically bootstrap any `lm` model supplied to `modelsummary`, and replace the values in the table automatically.
 


### PR DESCRIPTION
## Summary

Fixes 8 typos across roxygen documentation, error messages, and vignettes.

## Changes

**R source (roxygen & error messages):**
- : "funtions" → "functions"
- : "a tidy format" → "in a tidy format" (missing word)
- : "goodness-o-fit" → "goodness-of-fit"
- : "autmoatic" → "automatic"
- : Error message in `fmt_term()` incorrectly referenced `fmt_statistic()`
- : Garbled error message with stray "the name of your variable" fragment
- : Removed duplicate `statistic` row, moved `tli` to correct alphabetical position

**Vignettes:**
- : "If you to customize" → "If you want to customize"
- : "nomal" → "normal"
- : "Cutomizing" → "Customizing"
- : "emptyr" → "empty"

## Validation

- `R CMD build --no-build-vignettes` — success
- `R CMD check --no-manual --no-vignettes --no-tests` — Status: OK
- No open PRs covering these typos