### PR TITLE
fix: doubled 'the the' typos in modelplot.qmd and datasummary.qmd vignettes

### DIFF
--- a/vignettes/datasummary.qmd
+++ b/vignettes/datasummary.qmd
@@ -302,7 +302,7 @@ By default, `All` selects all numeric variables. This behavior can be changed by
 
 ## Nesting with `*`
 
-`datasummary` can nest variables and statistics inside categorical variables using the `*` symbol. When applying the the `*` operator to factor, character, or logical variables, columns or rows will automatically be nested. For instance, if we want to display separate means for each value of the variable `sex`, we use `mean * sex`:
+`datasummary` can nest variables and statistics inside categorical variables using the `*` symbol. When applying the `*` operator to factor, character, or logical variables, columns or rows will automatically be nested. For instance, if we want to display separate means for each value of the variable `sex`, we use `mean * sex`:
 
 ```{r}
 datasummary(flipper_length_mm + body_mass_g ~ mean * sex,

--- a/vignettes/modelplot.qmd
+++ b/vignettes/modelplot.qmd
@@ -145,7 +145,7 @@ models <- list(
   lm(hp ~ carb + mpg + cyl, data = mtcars))
 ```
 
-Then, we use the `dvnames` function to rename our list with names matching the the dependent variable in each model:
+Then, we use the `dvnames` function to rename our list with names matching the dependent variable in each model:
 
 ```{r}
 models <- dvnames(models)


### PR DESCRIPTION
## Summary

Fixes two doubled-word typos in vignette documentation.

## Changes

- `vignettes/modelplot.qmd:148`: "matching the the dependent" → "matching the dependent"
- `vignettes/datasummary.qmd:305`: "applying the the `\*`" → "applying the `\*``

## Validation

Both are documentation-only changes (no code behavior affected). Verified the typos exist on `origin/main`.