### PR TITLE
Match `coef_omit` against raw variable names, not display labels

### DIFF
--- a/R/format_estimates.R
+++ b/R/format_estimates.R
@@ -247,6 +247,8 @@ format_estimates <- function(
     group_name,
     'group',
     'term',
+    # raw variable names, kept for `coef_omit` in `map_estimates()`
+    'modelsummary_raw_coef',
     paste0('modelsummary_tmp', seq_along(estimate_glue))
   )
   cols <- intersect(cols, colnames(est))

--- a/R/get_estimates.R
+++ b/R/get_estimates.R
@@ -311,6 +311,12 @@ get_estimates_parameters <- function(
   if (isTRUE(coef_rename)) {
     labs <- attr(out, "pretty_labels")
     labs <- gsub("\\*", "\u00d7", labs)
+    # Keep the raw variable names alongside the labels. `coef_omit` matches on
+    # these, so a regex written against the model's variables keeps working
+    # when `coef_rename = TRUE` swaps the terms for variable labels. The column
+    # is carried through `format_estimates()` and dropped in `map_estimates()`
+    # as soon as `coef_omit` has been applied.
+    out[["modelsummary_raw_coef"]] <- out$term
     out$term <- replace_dict(out$term, labs)
     out$term <- gsub("\\*", "\u00d7", out$term)
   }

--- a/R/map_estimates.R
+++ b/R/map_estimates.R
@@ -28,8 +28,18 @@ map_estimates <- function(
   }
 
   # coef_omit
+  # Always matched against the raw variable names, never against display
+  # labels: `coef_rename = TRUE` relabels terms during extraction, and a regex
+  # written against the model's variables must keep working regardless.
+  # `modelsummary_raw_coef` is absent when no renaming happened, in which case
+  # `term` already holds the raw names.
+  raw_coef <- if ("modelsummary_raw_coef" %in% colnames(estimates)) {
+    estimates[["modelsummary_raw_coef"]]
+  } else {
+    estimates$term
+  }
   if (is.character(coef_omit)) {
-    idx <- !grepl(coef_omit, estimates$term, perl = TRUE)
+    idx <- !grepl(coef_omit, raw_coef, perl = TRUE)
     if (sum(idx) > 0) {
       estimates <- estimates[idx, , drop = FALSE]
     } else {
@@ -56,6 +66,12 @@ modelsummary(mod, coef_omit = "^(?!.*ei|.*pt)")
 '
       stop(msg, call. = FALSE)
     }
+  }
+
+  # the raw names have served their purpose; drop them so they never reach the
+  # merge, the reshaping or the printed table
+  if ("modelsummary_raw_coef" %in% colnames(estimates)) {
+    estimates[["modelsummary_raw_coef"]] <- NULL
   }
 
   # coef_rename

--- a/R/modelsummary.R
+++ b/R/modelsummary.R
@@ -137,8 +137,10 @@ globalVariables(c(
 #' * `"^(?!.*ei)"`: keep coefficients matching the "ei" substring.
 #' * `"^(?!.*ei|.*pt)"`: keep coefficients matching either the "ei" or the "pt" substrings.
 #' * See the Examples section below for complete code.
+#'
+#' Regular expressions are always matched against the **raw variable names** of the model, never against the labels that `coef_rename` may substitute for them. `coef_omit="start_year"` therefore drops `factor(start_year)2008` whether or not `coef_rename=TRUE` relabels it to "StartYear [2008]". Note that the raw names are matched as a regex, so parentheses must be escaped: use `"factor\\(cyl\\)"`, not `"factor(cyl)"`.
 #' @param coef_rename logical, named or unnamed character vector, or function
-#' * Logical: TRUE renames variables based on the "label" attribute of each column. See the Example section below. Note: renaming is done by the `parameters` package at the extraction stage, before other arguments are applied like `coef_omit`. Therefore, this only works for models with builtin support and not for custom models.
+#' * Logical: TRUE renames variables based on the "label" attribute of each column. See the Example section below. Note: renaming is done by the `parameters` package at the extraction stage. This only works for models with builtin support and not for custom models. The raw variable names are retained internally, so `coef_omit` still matches on them rather than on the labels.
 #' * Unnamed character vector of length equal to the number of coefficients in the final table, after `coef_omit` is applied.
 #' * Named character vector: Values refer to the variable names that will appear in the table. Names refer to the original term names stored in the model object. Ex: c("hp:mpg"="hp X mpg")
 #' * Function: Accepts a character vector of the model's term names and returns a named vector like the one described above. The `modelsummary` package supplies a `coef_rename()` function which can do common cleaning tasks: `modelsummary(model, coef_rename = coef_rename)`


### PR DESCRIPTION
### Problem

When `coef_rename = TRUE`, renaming happens during extraction in `get_estimates_parameters()`, so by the time `map_estimates()` applies `coef_omit` the `term` column already holds variable **labels**. A regex written against the model's own variables therefore silently matches nothing.

```r
library(modelsummary)
library(labelled)

dat <- data.frame(y = rnorm(100), start_year = sample(2010:2013, 100, TRUE))
dat <- set_variable_labels(dat, start_year = "StartYear")
mod <- lm(y ~ factor(start_year), data = dat)

# expected: cohort dummies dropped. actual: all of them are kept,
# because the terms are "StartYear [2011]" by the time coef_omit runs
modelsummary(mod, coef_rename = TRUE, coef_omit = "start_year")
```

The failure is silent: nothing warns that the pattern matched no coefficient, so the dummies simply appear in the finished table. It is also awkward to work around, since the string you must write depends on whether a label happens to exist (`"start_year"` vs `"start.?year"` vs `"(?i)start.?year"`).

### Fix

Keep the pre-rename names in a `modelsummary_raw_coef` column, carry it through the column whitelist in `format_estimates()`, match `coef_omit` against it, then drop it as soon as it has been used so it never reaches the merge, the reshape, or the printed table.

When no renaming happened the column is absent and `term` already holds the raw names, so behaviour is unchanged.

### Notes

- `coef_omit` remains a regex, so parentheses still need escaping (`"factor\\(cyl\\)"`).
- Documentation updated: the `coef_rename` entry previously said renaming happens "before other arguments are applied like `coef_omit`", which is what this changes.
- Full tinytest suite passes locally (757 assertions, 0 failures, 65 files) with `lfe`, `lavaan`, `gamlss`, `betareg` and `clubSandwich` installed.