### PR TITLE
Attach model packages on future workers

### DIFF
--- a/R/modelsummary.R
+++ b/R/modelsummary.R
@@ -1035,6 +1035,67 @@ modelsummary <- function(
 }
 
 
+#' Packages a parallel worker must attach to handle these models
+#'
+#' `future` decides which packages to attach on a worker by static analysis of
+#' the function it is given. `inner_loop()` names only `modelsummary`'s own
+#' extractors, never the package that defines the model class, so a worker can
+#' receive a model it cannot dispatch on. The extractor then fails there with
+#' e.g. `could not find function "glmmTMB"`, `get_gof()` swallows the error, and
+#' the user sees only the generic "could not extract goodness-of-fit statistics
+#' from a model of class ..." warning -- once per model, with every GOF row
+#' silently missing from the table. Sequential runs are unaffected, and so are
+#' single-model tables (the `future` branch requires `number_of_models > 1`),
+#' which makes the failure look erratic.
+#'
+#' Returns only namespaces already loaded in the main session, so a worker is
+#' never asked to attach something unavailable to it.
+#'
+#' @keywords internal
+#' @noRd
+model_packages <- function(models) {
+  # `inherits()`, not `is.list()`: a fitted model usually IS a list, so
+  # `is.list()` would make a single model look like a list of models and
+  # iterate over its components instead.
+  if (!inherits(models, "list")) {
+    models <- list(models)
+  }
+  # generics whose methods a GOF/estimates extractor is likely to need, and
+  # which a modelling package almost always provides for its own class
+  generics <- c("logLik", "vcov", "predict", "nobs", "summary", "terms")
+
+  one <- function(model) {
+    classes <- class(model)
+    # S4 and R5 record the defining package directly
+    pkg <- attr(classes, "package")
+    if (!is.null(pkg)) {
+      return(pkg)
+    }
+    # S3: find where the class's methods are registered
+    for (cl in classes) {
+      for (gen in generics) {
+        fun <- tryCatch(
+          utils::getS3method(gen, cl, optional = TRUE),
+          error = function(e) NULL
+        )
+        if (is.function(fun)) {
+          nm <- environmentName(topenv(environment(fun)))
+          # base packages are always available on a worker
+          if (nzchar(nm) && !nm %in% c("R_GlobalEnv", "base", "stats")) {
+            return(nm)
+          }
+        }
+      }
+    }
+    character(0)
+  }
+
+  out <- unique(unlist(lapply(models, one)))
+  out <- out[!is.na(out) & nzchar(out)]
+  out[out %in% loadedNamespaces()]
+}
+
+
 get_list_of_modelsummary_lists <- function(
   models,
   conf_level,
@@ -1109,7 +1170,8 @@ get_list_of_modelsummary_lists <- function(
       future.apply::future_lapply(
         seq_len(number_of_models),
         inner_loop,
-        future.seed = TRUE
+        future.seed = TRUE,
+        future.packages = model_packages(models)
       ),
       silent = TRUE
     )

--- a/inst/tinytest/test-model_packages.R
+++ b/inst/tinytest/test-model_packages.R
@@ -1,0 +1,61 @@
+source("helpers.R")
+using("modelsummary")
+
+# `model_packages()` tells `future` which namespaces a worker must attach to
+# handle the models. Getting it wrong is not loud: the worker fails to dispatch,
+# `get_gof()` swallows the error, and the table silently loses every GOF row
+# while warning about the model class instead.
+
+mp <- modelsummary:::model_packages
+
+# base-package classes need nothing extra: stats and base are always there
+mod_lm <- lm(mpg ~ wt, data = mtcars)
+expect_true(!"stats" %in% mp(mod_lm))
+expect_true(!"base" %in% mp(mod_lm))
+
+mod_glm <- glm(am ~ wt, data = mtcars, family = binomial())
+expect_true(!"stats" %in% mp(mod_glm))
+
+# a single model may be passed unwrapped or in a list. A fitted model IS a
+# list, so an `is.list()` guard here would iterate over its components and
+# silently return nothing -- this is the regression test for that.
+expect_equal(mp(mod_lm), mp(list(mod_lm)))
+expect_equal(mp(mod_glm), mp(list(mod_glm)))
+
+# every returned name must be a loaded namespace, or the worker cannot attach it
+expect_true(all(mp(list(mod_lm, mod_glm)) %in% loadedNamespaces()))
+
+# the real case: a class whose methods live in a contributed package
+if (requireNamespace("MASS", quietly = TRUE)) {
+  set.seed(1)
+  dat <- data.frame(x = rnorm(200))
+  dat$y <- MASS::rnegbin(200, mu = exp(1 + 0.5 * dat$x), theta = 2)
+  mod_nb <- MASS::glm.nb(y ~ x, data = dat)
+  expect_true("MASS" %in% mp(mod_nb))
+  # and it is picked up alongside others, without duplicates
+  both <- mp(list(mod_lm, mod_nb, mod_nb))
+  expect_true("MASS" %in% both)
+  expect_equal(anyDuplicated(both), 0L)
+}
+
+if (requireNamespace("glmmTMB", quietly = TRUE)) {
+  set.seed(2)
+  dat <- data.frame(x = rnorm(200))
+  dat$y <- rpois(200, lambda = exp(1 + 0.4 * dat$x))
+  mod_tmb <- glmmTMB::glmmTMB(y ~ x, data = dat, family = stats::poisson)
+  expect_true("glmmTMB" %in% mp(mod_tmb))
+}
+
+# unknown / classless objects must not error, and must not invent a package
+expect_equal(length(mp(structure(list(), class = "no_such_model_class"))), 0L)
+expect_equal(length(mp(list())), 0L)
+
+# a modelsummary_list carries its own estimates and needs no modelling package
+ml <- structure(
+  list(
+    tidy = data.frame(term = "a", estimate = 1),
+    glance = data.frame(nobs = 1)
+  ),
+  class = "modelsummary_list"
+)
+expect_true(all(mp(ml) %in% loadedNamespaces()))


### PR DESCRIPTION
### Problem

With a `future` plan of more than one worker, a table of more than one model
silently loses **every** goodness-of-fit row.

```r
library(modelsummary); library(glmmTMB); library(future)

set.seed(1)
d <- data.frame(x = rnorm(300), z = rnorm(300))
d$y <- rpois(300, lambda = exp(1 + 0.4 * d$x))
mods <- list(
  a = glmmTMB(y ~ x,     data = d, family = poisson),
  b = glmmTMB(y ~ x + z, data = d, family = poisson)
)

plan(sequential)
modelsummary(mods)                  # Num.Obs., AIC, BIC, RMSE   <- fine

plan(multisession, workers = 2)
modelsummary(mods)                  # no GOF rows at all
#> Warning: `modelsummary` could not extract goodness-of-fit statistics from a
#> model of class "glmmTMB". ...   (once per model)
```

The table is still produced, only without its GOF block, so this is easy to
ship without noticing.

### Cause

`get_list_of_modelsummary_lists()` dispatches the per-model extraction to
`future.apply::future_lapply()` when `number_of_models > 1` and the plan has
more than one worker.

`future` decides which packages to attach on a worker by static analysis of the
function it is handed. `inner_loop()` names only modelsummary's own extractors,
never the package that defines the model class, so `future` never learns that
`glmmTMB` is needed:

```r
gl <- globals::globalsOf(inner_loop, envir = environment(), mustExist = FALSE)
globals::packagesOf(gl)
#> [1] "base"
```

Deserialising the model does *load* the `glmmTMB` namespace on the worker, but
does not attach it, and that is not enough: the extractor re-evaluates the
model's call and dies with

```
could not find function "glmmTMB"
```

`get_gof()` catches that and returns the generic message, so the class gets the
blame rather than the plan.

Two details make it awkward to attribute. A single-model table is unaffected,
because the `future` branch requires `number_of_models > 1` — so the same model
keeps its GOF rows alone and loses them in a list. And it is class- and
metric-dependent: in the example above a `glmmTMB` model *with* a random effect
survives (a different R2 path), while the fixed-effects-only models above fail
every time.

### Fix

Add `model_packages()` and pass its result as `future.packages`. It reads the
defining package from the class attribute for S4/R5 models and, for S3 models,
from where the class's methods are registered. Only namespaces already loaded
in the main session are returned, so a worker is never asked to attach
something unavailable to it.

One detail worth a reviewer's eye: the "single model or list of models?" guard
uses `inherits(x, "list")` rather than `is.list()`. A fitted model usually *is*
a list, so `is.list()` iterates over a lone model's components and finds
nothing. There is a regression test for that.

### Tests

`inst/tinytest/test-model_packages.R` — 13 assertions: base-package classes
contribute nothing (`stats`/`base` are always present on a worker), contributed
packages (`MASS`, `glmmTMB`) are found, results are deduplicated and restricted
to loaded namespaces, unknown and classless objects neither error nor invent a
package, a `modelsummary_list` needs no modelling package, and a single model
gives the same answer as a one-element list.

Verified against the reproducer above: unpatched `main` gives 2 warnings and no
GOF rows under `multisession`; with the patch, 0 warnings and
`Num.Obs., AIC, BIC, RMSE` under both plans. Full `tinytest` suite: no new
failures.
