### PR TITLE
Fix flextable rbind panel labels placement

### DIFF
--- a/R/factory_flextable.R
+++ b/R/factory_flextable.R
@@ -32,6 +32,26 @@ factory_flextable <- function(
   # measurements
   table_width <- ncol(tab)
 
+  # horizontal grouping (hgroup): insert full-width group rows in the body
+  has_hgroup <- !is.null(hgroup) && length(hgroup) > 0
+  if (has_hgroup) {
+    # insert from last to first so earlier row indices stay valid
+    for (nm in rev(names(hgroup))) {
+      rng <- hgroup[[nm]]
+      grp <- data.frame(matrix("", nrow = 1, ncol = ncol(tab)))
+      colnames(grp) <- colnames(tab)
+      grp[1, 1] <- nm
+      tab <- rbind(
+        tab[seq_len(rng[1] - 1), , drop = FALSE],
+        grp,
+        tab[rng[1]:nrow(tab), , drop = FALSE]
+      )
+    }
+    if (!is.null(hrule)) {
+      hrule <- hrule + length(hgroup)
+    }
+  }
+
   # flextable object
   out <- flextable::flextable(tab)
 
@@ -86,16 +106,18 @@ factory_flextable <- function(
     }
   }
 
-  # horizontal grouping (hgroup)
-  if (!is.null(hgroup) && length(hgroup) > 0) {
-    # hgroup creates grouped rows in the body
-    for (group_name in names(hgroup)) {
-      group_rows <- hgroup[[group_name]]
-      if (length(group_rows) > 0) {
-        # add a row above the first row of each group
-        first_row <- min(group_rows)
-        out <- flextable::add_header_lines(out, values = group_name)
-        out <- flextable::align(out, i = 1, align = "left", part = "header")
+  # merge group rows across all columns
+  if (has_hgroup) {
+    stub <- trimws(as.character(out$body$dataset[[1]]))
+    for (nm in names(hgroup)) {
+      i <- which(stub == nm)
+      if (length(i) == 1) {
+        out <- flextable::merge_h_range(
+          out,
+          i = i,
+          j1 = 1,
+          j2 = length(out$col_keys)
+        )
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #974.

`factory_flextable()` rendered the `hgroup` argument (a named list of body row
ranges, e.g. `"Panel A" = c(1, 2)` for `shape = "rbind"`) with
`flextable::add_header_lines()`, which pushed every panel label into the
**header** rows of the table instead of inserting a group row in the **body**.

This patch inserts a full-width group row at the start of each panel segment in
the body (matching the behavior of the `tinytable` and `kableExtra` factories),
then merges each group row across all columns.

## Expected behavior

```r
library(modelsummary)

panels <- list(
  "Panel A" = lm(mpg ~ hp, data = mtcars),
  "Panel B" = lm(disp ~ hp, data = mtcars)
)

modelsummary(panels, shape = "rbind", output = "flextable", gof_omit = ".*")
```

`Panel A` and `Panel B` now appear as merged, full-width group rows in the body
at the start of each panel, matching the `tinytable` output.

## Changes

- `R/factory_flextable.R`: insert panel group rows into the body before
  building the table (in reverse order so earlier row indices stay valid),
  shift `hrule` accordingly, and merge the inserted rows across all columns.

## Checks

- rbind flextable: header only contains model labels; `Panel A`/`Panel B` are
  merged body group rows.
- `rcollapse` flextable (combined GOF + `hrule`) still correct.
- Non-hgroup flextable output unchanged.
- HTML / docx / png exports work.
- Default `tinytable` output and rbind dataframe logic unchanged.