### PR TITLE
Fix: rbind shape ignores modelsummary_stars_note option

### DIFF
--- a/R/modelsummary_rbind.R
+++ b/R/modelsummary_rbind.R
@@ -231,7 +231,12 @@ modelsummary_rbind <- function(
   }
 
   # stars
-  if (!isFALSE(stars) && !any(grepl("\\{stars\\}", c(estimate, statistic)))) {
+  stars_note <- settings_get("stars_note")
+  if (
+    isTRUE(stars_note) &&
+      !isFALSE(stars) &&
+      !any(grepl("\\{stars\\}", c(estimate, statistic)))
+  ) {
     stars_note <- make_stars_note(
       stars,
       output_format = output_format,


### PR DESCRIPTION
## Problem

When `modelsummary_stars_note = FALSE`, the main `modelsummary()` function correctly suppresses the significance note, but the `shape = "rbind"` path ignores this option and still shows it. The two paths behave inconsistently.

## Minimal reproduction

```r
library(modelsummary)
options(modelsummary_stars_note = FALSE)
modelsummary(
  list("A" = lm(mpg ~ hp, mtcars), "B" = lm(disp ~ hp, mtcars)),
  shape = "rbind", stars = TRUE, output = "markdown"
)
# the "p < 0.1, * p < 0.05 ..." note is still printed
```

## Fix

Added an `isTRUE(settings_get("stars_note"))` guard in `R/modelsummary_rbind.R`, aligning it with the main function's logic. Default behavior is unchanged.

## Verification

- With `stars_note = FALSE`, the note is correctly suppressed
- With `stars_note = TRUE` (default), the note is still shown