### PR TITLE
Weight categorical counts and percentages in datasummary_balance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@
 
 ## Development
 
+- Behavior change: `datasummary_balance()` now weights the counts and
+  percentages of categorical variables when the `data` include a
+  “weights” column, so the categorical and numeric blocks of the table
+  describe the same population. The “N” column reports the sum of
+  weights in each cell, and the “Pct.” column reports the weighted share
+  of the column. The warning about unweighted categorical statistics is
+  removed. Fixes Issue \#500.
 - `shape = term ~ model + statistic` now handles model labels containing
   structural column names such as `term`. Fixes Issue \#977.
 - `align = "d"` with LaTeX output no longer mangles p-values printed

--- a/NEWS.qmd
+++ b/NEWS.qmd
@@ -6,6 +6,7 @@ format: gfm
 
 ## Development
 
+* Behavior change: `datasummary_balance()` now weights the counts and percentages of categorical variables when the `data` include a "weights" column, so the categorical and numeric blocks of the table describe the same population. The "N" column reports the sum of weights in each cell, and the "Pct." column reports the weighted share of the column. The warning about unweighted categorical statistics is removed. Fixes Issue \#500.
 * `shape = term ~ model + statistic` now handles model labels containing structural column names such as `term`. Fixes Issue \#977.
 * `align = "d"` with LaTeX output no longer mangles p-values printed with a leading comparator, such as `<0.001`. The comparator was typeset outside its column and collided with the neighboring one. Fixed upstream in `tinytable`. Issue \#880.
 * `shape = "rbind"` now respects the `modelsummary_stars_note` global option, so the significance note is suppressed when that option is set to `FALSE`, matching the behavior of `modelsummary()`. Thanks to @ykonut for pull request \#976.

--- a/R/datasummary_balance.R
+++ b/R/datasummary_balance.R
@@ -15,7 +15,9 @@
 #' @param data A data.frame (or tibble). If this data includes columns called
 #'   "blocks", "clusters", and/or "weights", the "estimatr" package will consider
 #'   them when calculating the difference in means. If there is a `weights`
-#'   column, the reported mean and standard errors will also be weighted.
+#'   column, the reported mean and standard errors will also be weighted. For
+#'   categorical variables, the "N" column then reports the sum of weights in
+#'   each cell, and the "Pct." column reports the weighted share of the column.
 #' @param dinm TRUE calculates a difference in means with uncertainty
 #'   estimates. This option is only available if the `estimatr` package is
 #'   installed. If `data` includes columns named "blocks", "clusters", or
@@ -182,17 +184,33 @@ datasummary_balance <- function(
     nformat <- function(x) {
       sanitize_fmt(0)(as.numeric(x))
     }
+    ## when a "weights" column is present, counts and percentages are weighted:
+    ## "N" becomes the sum of weights, and the percentage denominators are the
+    ## column-wise sums of weights.
+    if ("weights" %in% colnames(data)) {
+      wnformat <- sanitize_fmt(1)
+      weighted_n <- function(x) sum(x, na.rm = TRUE)
+      weighted_pct <- function(x, y) {
+        sum(x, na.rm = TRUE) / sum(y, na.rm = TRUE) * 100
+      }
+      stat_fac <- "weights * (Heading('N') * weighted_n * Format(wnformat()) +
+                 Heading('Pct.') * Percent('col', fn = weighted_pct) * Format(pctformat()))"
+    } else {
+      stat_fac <- "(N * Format(nformat()) +
+                 Heading('Pct.') * Percent('col') * Format(pctformat()))"
+    }
+
     if (!is.null(rhs)) {
       f_fac <- stats::as.formula(sprintf(
-        "All(tmp2, factor = TRUE, numeric = FALSE) ~
-                 Factor(%s) * (N * Format(nformat()) + Heading('Pct.') * Percent('col') * Format(pctformat()))",
-        rhs
+        "All(tmp2, factor = TRUE, numeric = FALSE) ~ Factor(%s) * %s",
+        rhs,
+        stat_fac
       ))
     } else {
-      f_fac <- stats::as.formula(
-        "All(tmp2, factor = TRUE, numeric = FALSE) ~
-                 (N * Format(nformat()) + Heading('Pct.') * Percent('col') * Format(pctformat()))"
-      )
+      f_fac <- stats::as.formula(sprintf(
+        "All(tmp2, factor = TRUE, numeric = FALSE) ~ %s",
+        stat_fac
+      ))
     }
     tab_fac <- datasummary(
       formula = f_fac,
@@ -366,12 +384,6 @@ datasummary_balance <- function(
       strrep("l", attr(tab, "stub_width")),
       strrep("r", ncol(tab) - attr(tab, "stub_width"))
     )
-  }
-
-  ## weights warning
-  if (isTRUE(any_factor) && "weights" %in% colnames(data)) {
-    msg <- 'When the `data` used in `datasummary_balance` contains a "weights" column, the means, standard deviations, difference in means, and standard errors of numeric variables are adjusted to account for weights. However, the counts and percentages for categorical variables are not adjusted.'
-    warning(msg, call. = FALSE)
   }
 
   ## make table

--- a/inst/tinytest/test-datasummary_balance.R
+++ b/inst/tinytest/test-datasummary_balance.R
@@ -368,13 +368,36 @@ expect_error(
   pattern = "include missing data"
 )
 
-# warning: weights not supported for categorical
+# Issue #500: counts and percentages of categorical variables are weighted
 set.seed(1024)
 datw <- mtcars
 datw$weights <- runif(nrow(datw))
 datw$am <- factor(datw$am)
 datw$cyl <- factor(datw$cyl)
-expect_warning(datasummary_balance(~am, data = datw), pattern = "However")
+tab <- datasummary_balance(
+  ~am,
+  data = datw[, c("am", "cyl", "weights")],
+  output = "data.frame"
+)
+for (am in levels(datw$am)) {
+  sub <- datw[datw$am == am, ]
+  # "N" is the sum of weights
+  unknown <- sprintf("%.1f", tapply(sub$weights, sub$cyl, sum))
+  expect_equivalent(unknown, tab[[sprintf("%s (N=%s) / N", am, nrow(sub))]])
+  # "Pct." is the weighted share of the column
+  unknown <- tapply(sub$weights, sub$cyl, sum) / sum(sub$weights) * 100
+  unknown <- sprintf("%.1f", unknown)
+  expect_equivalent(unknown, tab[[sprintf("%s (N=%s) / Pct.", am, nrow(sub))]])
+}
+
+# no "weights" column: counts and percentages are unweighted
+tab <- datasummary_balance(
+  ~am,
+  data = datw[, c("am", "cyl")],
+  output = "data.frame"
+)
+expect_equivalent(tab[[3]], c("3", "4", "12"))
+expect_equivalent(tab[[4]], c("15.8", "21.1", "63.2"))
 
 # numeric weights
 set.seed(1024)

--- a/man/datasummary_balance.Rd
+++ b/man/datasummary_balance.Rd
@@ -33,7 +33,9 @@ datasummary_balance(
 \item{data}{A data.frame (or tibble). If this data includes columns called
 "blocks", "clusters", and/or "weights", the "estimatr" package will consider
 them when calculating the difference in means. If there is a \code{weights}
-column, the reported mean and standard errors will also be weighted.}
+column, the reported mean and standard errors will also be weighted. For
+categorical variables, the "N" column then reports the sum of weights in
+each cell, and the "Pct." column reports the weighted share of the column.}
 
 \item{output}{filename or object type (character string)
 \itemize{


### PR DESCRIPTION
Fixes #500.

## Problem

When `data` includes a `weights` column, `datasummary_balance()` weighted the means, standard deviations, and difference in means of numeric variables, but the counts and percentages of categorical variables were left unweighted. The two blocks of the table therefore described different populations, and a warning documented the gap:

> However, the counts and percentages for categorical variables are not adjusted.

## Change

The categorical sub-table now respects the `weights` column too:

- **N** reports the sum of weights in each cell
- **Pct.** reports the weighted share of the column

The warning is removed. No new argument: the `weights` column is already a magic-column convention that applies automatically everywhere else in this function.

```
> datasummary_balance(~am, data = dat, output = "markdown")

|     |    | Mean | Std. Dev. | Mean | Std. Dev. | Diff. in Means | Std. Error |
|-----|----|------|-----------|------|-----------|----------------|------------|
| mpg |    | 17.3 | 4.1       | 24.7 | 6.7       | 7.4            | 2.4        |
|     |    | N    | Pct.      | N    | Pct.      |                |            |
| cyl | 4  | 11.9 | 20.3      | 24.4 | 63.0      |                |            |
|     | 6  | 12.3 | 20.9      | 6.9  | 17.8      |                |            |
|     | 8  | 34.5 | 58.8      | 7.4  | 19.1      |                |            |
```

## Notes

- **Behavior change.** Anyone with a `weights` column and a factor will see different numbers for the categorical rows. Flagged as such in NEWS.
- Weighted **N** is the sum of weights rather than a raw row count, so N and Pct. describe the same population (matching Stata's `tabulate [aw=]`).
- The unweighted path is unchanged: `stat_fac` falls back to the original `N` / `Percent('col')` terms when no `weights` column is present, and the existing tests cover it.

## Testing

- New assertions in `inst/tinytest/test-datasummary_balance.R` check the weighted N and Pct. against `tapply(w, f, sum)` computed by hand for each group, plus a regression check that the no-weights output is untouched.
- Full suite: 788 passed, 0 failed, 4 skipped.

Unrelated pre-existing bug noticed while testing (**not** fixed here): supplying a single-statistic `fn` together with a `weights` column and factor variables errors in `bind_rows` (`missing value where TRUE/FALSE needed`). Reproduces on `main`.