### PR TITLE
Significance note and `stars` rules for glue strings with {stars}

### DIFF
--- a/R/modelsummary.R
+++ b/R/modelsummary.R
@@ -86,7 +86,7 @@ globalVariables(c(
 #' * FALSE (default): no significance stars.
 #' * TRUE: `c("+" = .1, "*" = .05, "**" = .01, "***" = 0.001)`
 #' * Named numeric vector for custom stars such as `c('*' = .1, '+' = .05)`
-#' * Note: a legend will not be inserted at the bottom of the table when the `estimate` or `statistic` arguments use "glue strings" with `{stars}`.
+#' * Note: a legend is inserted at the bottom of the table whenever `stars` is not `FALSE` *or* the `estimate`/`statistic` arguments use "glue strings" with `{stars}`; suppress it with `options(modelsummary_stars_note = FALSE)`.
 #' @param statistic vector of strings or `glue` strings which select uncertainty statistics to report vertically below the estimate (ex: standard errors, confidence intervals, p values). NULL omits all uncertainty statistics.
 #' * "conf.int", "std.error", "statistic", "p.value", "conf.low", "conf.high", or any column name produced by `get_estimates(model)`
 #' * `glue` package strings with braces, with or without R functions, such as:
@@ -881,11 +881,13 @@ modelsummary <- function(
   stars_note <- settings_get("stars_note")
   if (
     isTRUE(stars_note) &&
-      !isFALSE(stars) &&
-      !any(grepl("\\{stars\\}", c(estimate, statistic)))
+      (!isFALSE(stars) ||
+        any(grepl("\\{stars\\}", c(estimate, statistic))))
   ) {
     stars_note <- make_stars_note(
-      stars,
+      # a {stars} glue with stars = FALSE is rendered with the default
+      # thresholds (see format_estimates.R), so the note must state those
+      if (isFALSE(stars)) TRUE else stars,
       output_format = output_format,
       output_factory = output_factory
     )

--- a/R/modelsummary.R
+++ b/R/modelsummary.R
@@ -87,6 +87,7 @@ globalVariables(c(
 #' * TRUE: `c("+" = .1, "*" = .05, "**" = .01, "***" = 0.001)`
 #' * Named numeric vector for custom stars such as `c('*' = .1, '+' = .05)`
 #' * Note: a legend is inserted at the bottom of the table whenever `stars` is not `FALSE` *or* the `estimate`/`statistic` arguments use "glue strings" with `{stars}`; suppress it with `options(modelsummary_stars_note = FALSE)`.
+#' * Cannot be combined with the `estimate` or `statistic` arguments: when those are customized, request stars by including `{stars}` in the glue string, which renders them with the default thresholds.
 #' @param statistic vector of strings or `glue` strings which select uncertainty statistics to report vertically below the estimate (ex: standard errors, confidence intervals, p values). NULL omits all uncertainty statistics.
 #' * "conf.int", "std.error", "statistic", "p.value", "conf.low", "conf.high", or any column name produced by `get_estimates(model)`
 #' * `glue` package strings with braces, with or without R functions, such as:
@@ -468,6 +469,27 @@ modelsummary <- function(
   }
 
   dots <- list(...)
+
+  # `stars` is redundant once `estimate` or `statistic` is customized: star
+  # placement then belongs to the glue string (`{stars}`), and the
+  # significance note follows from its presence. Reject the mix instead of
+  # guessing which specification wins. Internal calls (modelplot, the
+  # per-panel calls of modelsummary_rbind) set estimate/statistic themselves,
+  # so they are exempt via the function_called marker, which they set before
+  # delegating here.
+  if (
+    !missing(stars) &&
+      (!missing(estimate) || !missing(statistic)) &&
+      !settings_equal("function_called", c("modelplot", "modelsummary_rbind"))
+  ) {
+    stop(
+      "The `stars` argument cannot be combined with `estimate` or `statistic`. ",
+      "To display significance stars with a custom `estimate` or `statistic`, ",
+      "include {stars} in the glue string; the significance note is then ",
+      "added automatically with the default thresholds.",
+      call. = FALSE
+    )
+  }
 
   ## settings
   if (!settings_equal("function_called", "modelsummary_rbind")) {

--- a/R/modelsummary_rbind.R
+++ b/R/modelsummary_rbind.R
@@ -234,11 +234,12 @@ modelsummary_rbind <- function(
   stars_note <- settings_get("stars_note")
   if (
     isTRUE(stars_note) &&
-      !isFALSE(stars) &&
-      !any(grepl("\\{stars\\}", c(estimate, statistic)))
+      (!isFALSE(stars) || any(grepl("\\{stars\\}", c(estimate, statistic))))
   ) {
     stars_note <- make_stars_note(
-      stars,
+      # a {stars} glue with stars = FALSE is rendered with the default
+      # thresholds (see format_estimates.R), so the note must state those
+      if (isFALSE(stars)) TRUE else stars,
       output_format = output_format,
       output_factory = output_factory
     )


### PR DESCRIPTION
Emit the significance note when a glue string contains {stars}

A custom estimate/statistic glue string with {stars} renders stars (with
the default thresholds when `stars` is not set), but the note stating the
thresholds was suppressed exactly in that case. Emit it instead: the note
follows from the stars being displayed, however they were requested. A
{stars} glue with stars = FALSE renders default thresholds (see
format_estimates.R), so the note states those.

Reject `stars` combined with custom `estimate` or `statistic`

With a customized estimate/statistic, star placement belongs to the glue
string ({stars}, rendered with the default thresholds) and the note
follows from its presence, so a `stars` argument on top is ambiguous.
Error out instead of guessing. Internal callers that set
estimate/statistic themselves (modelplot, the per-panel calls of
modelsummary_rbind) are exempt via the function_called marker.