### PR TITLE
Derive the requested performance metrics from an explicit gof_map

### DIFF
--- a/R/get_gof.R
+++ b/R/get_gof.R
@@ -187,6 +187,75 @@ get_gof_broom <- function(model, ...) {
 }
 
 
+# Statistics that `metrics = "common"` asks {performance} for. Only these are
+# ever dropped by `metrics_from_gof_map()`, so a whitelist entry that maps to
+# none of them -- `nobs`, IV diagnostics, anything from `gof_function()` or the
+# broom backend -- is unaffected and does not need to be recognised below.
+metrics_common <- c("AIC", "AICc", "BIC", "R2", "R2_adj", "ICC", "RMSE")
+
+# Statistic name -> the {performance} metric that produces it. Both spellings
+# are accepted: the raw name as `insight::standardize_names()` emits it, and the
+# clean label used by `modelsummary::gof_map`.
+#
+# R2 is matched by pattern rather than enumerated, because which flavour
+# `"common"` returns depends on the model class: r.squared/adj.r.squared for lm
+# and glmmTMB, r2.conditional/r2.marginal for lmer and glmer, r2.tjur for
+# logistic glm, r2.nagelkerke for Poisson glm. Every one of them comes from the
+# single "R2" metric, so a pattern keeps unfamiliar flavours working instead of
+# silently dropping the row.
+#
+# "R2" and "R2_adj" are kept distinct on purpose. Some classes return both from
+# a bare "R2" request (glmmTMB does), but others do not: for `lm`, asking only
+# for "R2" silently drops adj.r.squared from the output.
+metrics_for_statistic <- function(x) {
+  x <- as.character(x)
+  out <- rep(NA_character_, length(x))
+  out[grepl("^aicc$", x, ignore.case = TRUE)] <- "AICc"
+  out[grepl("^aic$", x, ignore.case = TRUE)] <- "AIC"
+  out[grepl("^bic$", x, ignore.case = TRUE)] <- "BIC"
+  out[grepl("^rmse$", x, ignore.case = TRUE)] <- "RMSE"
+  # mixed models add ICC to the common set
+  out[grepl("^icc$", x, ignore.case = TRUE)] <- "ICC"
+  is_r2 <- grepl("r2|r\\.squared", x, ignore.case = TRUE)
+  # adjusted flavours first: "adj.r.squared", "R2 Adj.", "r2.within.adjusted"
+  out[is.na(out) & is_r2 & grepl("adj", x, ignore.case = TRUE)] <- "R2_adj"
+  out[is.na(out) & is_r2] <- "R2"
+  out
+}
+
+#' Narrow the metrics requested from `performance` to those the table can show
+#'
+#' When the user supplies an explicit `gof_map` whitelist, `map_gof()` discards
+#' every statistic that is not on it, so computing the rest is wasted work. R2
+#' in particular dominates the cost of `model_performance()` for many model
+#' classes, and a table that does not display it should not pay for it.
+#'
+#' Falls back to `"common"` whenever the map is not a whitelist, or when no
+#' entry is recognised, so the default behaviour is unchanged. Users who need
+#' exact control can still pass `metrics` themselves, which bypasses this.
+#'
+#' @keywords internal
+#' @noRd
+metrics_from_gof_map <- function(gof_map) {
+  if (!isTRUE(attr(gof_map, "whitelist"))) {
+    return("common")
+  }
+  keys <- unlist(lapply(gof_map, function(g) c(g[["raw"]], g[["clean"]])))
+  wanted <- metrics_for_statistic(keys)
+  wanted <- intersect(metrics_common, unique(stats::na.omit(wanted)))
+  # nothing recognised: the whitelist is served from another backend, but keep
+  # the default rather than assuming no `performance` statistic is wanted
+  if (length(wanted) == 0) {
+    return("common")
+  }
+  # everything wanted: keep the keyword, since `"common"` may cover more
+  # statistics than we know about for some model classes
+  if (all(metrics_common %in% wanted)) {
+    return("common")
+  }
+  return(wanted)
+}
+
 #' Extract goodness-of-fit statistics from a single model using
 #' the `performance` package
 #'
@@ -228,7 +297,7 @@ get_gof_parameters <- function(model, ...) {
     ) {
       args[["metrics"]] <- c("RMSE", "R2", "R2_adj")
     } else {
-      args[["metrics"]] <- "common"
+      args[["metrics"]] <- metrics_from_gof_map(dots[["gof_map"]])
     }
   }
 

--- a/inst/tinytest/test-gof_metrics_from_map.R
+++ b/inst/tinytest/test-gof_metrics_from_map.R
@@ -1,0 +1,92 @@
+source("helpers.R")
+
+# `metrics_from_gof_map()` narrows the statistics requested from {performance}
+# to those an explicit `gof_map` whitelist can actually display.
+
+mk <- function(x) modelsummary:::sanitize_gof_map(x)
+
+# not a whitelist -> unchanged
+expect_equal(modelsummary:::metrics_from_gof_map(mk(NULL)), "common")
+expect_equal(modelsummary:::metrics_from_gof_map(mk("all")), "common")
+
+# whitelist without R2 -> the expensive metric is not requested
+expect_equal(
+  modelsummary:::metrics_from_gof_map(mk(c("aic", "bic", "nobs"))),
+  c("AIC", "BIC")
+)
+expect_false("R2" %in% modelsummary:::metrics_from_gof_map(mk(c("rmse", "nobs"))))
+
+# whitelist with R2 -> R2 is requested
+expect_true("R2" %in% modelsummary:::metrics_from_gof_map(mk(c("r.squared", "nobs"))))
+
+# adjusted R2 is a distinct metric: some classes (lm) do not return it from a
+# bare "R2" request, so asking only for "R2" would silently drop the row
+expect_equal(modelsummary:::metrics_from_gof_map(mk("adj.r.squared")), "R2_adj")
+expect_equal(
+  modelsummary:::metrics_from_gof_map(mk(c("r.squared", "adj.r.squared"))),
+  c("R2", "R2_adj")
+)
+
+# nothing recognisable -> unchanged, rather than guessing nothing is needed
+expect_equal(modelsummary:::metrics_from_gof_map(mk(c("nobs", "vcov.type"))), "common")
+
+# everything wanted -> keep the keyword, which may cover more for some classes
+expect_equal(
+  modelsummary:::metrics_from_gof_map(
+    mk(c("aic", "aicc", "bic", "r.squared", "adj.r.squared", "icc", "rmse"))
+  ),
+  "common"
+)
+
+# --- every statistic `"common"` can produce must be recognised -----------------
+# Which R2 flavour `"common"` returns depends on the model class. An unmapped
+# flavour would be dropped whenever the whitelist also names something we do
+# recognise, e.g. gof_map = c("aic", "r2.tjur") on a logistic glm.
+requiet("lme4")
+set.seed(1)
+n <- 300
+dat <- data.frame(
+  y = rnbinom(n, mu = 4, size = 2),
+  b = rbinom(n, 1, .4),
+  x = rnorm(n),
+  g = factor(sample(letters[1:8], n, TRUE))
+)
+mods <- list(
+  lm = lm(y ~ x, dat),
+  logit = glm(b ~ x, dat, family = binomial),
+  poisson = glm(y ~ x, dat, family = poisson),
+  lmer = suppressMessages(lme4::lmer(y ~ x + (1 | g), data = dat))
+)
+for (nm in names(mods)) {
+  common <- suppressWarnings(performance::model_performance(
+    mods[[nm]], metrics = "common", verbose = FALSE))
+  common <- colnames(insight::standardize_names(common, style = "broom"))
+  expect_true(all(!is.na(modelsummary:::metrics_for_statistic(common))))
+}
+
+# the concrete case: a recognised statistic alongside a class-specific R2
+expect_true("R2" %in% modelsummary:::metrics_from_gof_map(mk(c("aic", "r2.tjur"))))
+expect_true("R2" %in% modelsummary:::metrics_from_gof_map(mk(c("aic", "r2.nagelkerke"))))
+expect_true("R2" %in% modelsummary:::metrics_from_gof_map(mk(c("aic", "r2.conditional"))))
+
+# --- end to end: narrowing must never drop a row the table would have shown ---
+mod <- lm(mpg ~ hp + drat, mtcars)
+
+for (gm in list(
+  c("nobs", "r.squared"),
+  c("nobs", "adj.r.squared"),
+  c("nobs", "rmse"),
+  c("aic", "bic"),
+  c("nobs", "r.squared", "adj.r.squared", "rmse", "aic", "bic")
+)) {
+  narrowed <- modelsummary(mod, output = "data.frame", gof_map = gm)
+  # force the old behaviour for comparison
+  wide <- modelsummary(mod, output = "data.frame", gof_map = gm, metrics = "common")
+  expect_equivalent(narrowed, wide)
+}
+
+# a whitelist naming a statistic {performance} never returns is still served
+# from the other backend, and is unaffected by the narrowing
+tab <- modelsummary(mod, output = "data.frame", gof_map = c("nobs", "rmse"))
+expect_true("Num.Obs." %in% tab$term)
+expect_true("RMSE" %in% tab$term)


### PR DESCRIPTION
Derive the requested performance metrics from an explicit gof_map

`get_gof_parameters()` always asked `performance::model_performance()` for
`metrics = "common"`. When the user supplies an explicit `gof_map` whitelist,
`map_gof()` then discards every statistic that is not on it, so much of that
work can be wasted. R2 dominates the cost: on a glmmTMB model with 30
coefficients and n = 3,000, `metrics = "common"` takes 65ms of which R2 alone
accounts for 60ms, against 10ms for AIC and roughly nothing for BIC and RMSE. A
table that does not display R2 should not pay for it.

Narrowing is confined to the statistics `"common"` itself produces, which is
what makes it safe: a whitelist entry mapping to none of them -- `nobs`, IV
diagnostics, anything from `gof_function()` or the broom backend -- is served
from elsewhere and is unaffected either way. Falls back to `"common"` when the
map is not a whitelist, when no entry is recognised, and when every droppable
metric is wanted anyway. Passing `metrics` explicitly bypasses all of this.

Which statistics `"common"` returns depends on the model class, so the mapping
had to be built against real output rather than guessed:

  lm, glmmTMB   aic, bic, r.squared, adj.r.squared, rmse
  lmer, glmer   aic, bic, r2.conditional, r2.marginal, icc, rmse
  glm binomial  aic, bic, r2.tjur, rmse
  glm poisson   aic, bic, r2.nagelkerke, rmse

R2 is therefore matched by pattern rather than enumerated: every flavour comes
from the single "R2" metric, and an unrecognised one would be dropped whenever
the whitelist also named something familiar, e.g. c("aic", "r2.tjur") on a
logistic model. ICC is included because mixed models add it to the common set.

"R2" and "R2_adj" are kept distinct on purpose. Some classes return both from a
bare "R2" request and glmmTMB is one of them, but `lm` is not: asking only for
"R2" there silently drops adj.r.squared.

A test asserts that everything `"common"` produces stays mapped, across the four
classes above, so a future flavour cannot go missing unnoticed.